### PR TITLE
Reseller module

### DIFF
--- a/packages/registration/sources/register.move
+++ b/packages/registration/sources/register.move
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module registration::register {
+    use std::option::{Option};
     use std::string::{Self, String};
     use sui::coin::{Self, Coin};
     use sui::tx_context::TxContext;
@@ -36,6 +37,7 @@ module registration::register {
         no_years: u8,
         payment: Coin<SUI>,
         clock: &Clock,
+        reseller: Option<String>,
         ctx: &mut TxContext
     ): SuinsRegistration {
         suins::assert_app_is_authorized<Register>(suins);
@@ -52,7 +54,8 @@ module registration::register {
 
         assert!(coin::value(&payment) == price, EIncorrectAmount);
 
-        suins::app_add_balance(Register {}, suins, coin::into_balance(payment));
+        suins::reseller::handle_payment<Register>(Register {}, suins, payment, reseller, ctx);
+
         let registry = suins::app_registry_mut<Register, Registry>(Register {}, suins);
         registry::add_record(registry, domain, no_years, clock, ctx)
     }

--- a/packages/suins/sources/reseller.move
+++ b/packages/suins/sources/reseller.move
@@ -1,0 +1,139 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This module:
+// 1. Acts as a proxy for authorized apps to be able to register paying reseller fees (paying commission)
+// 2. Allows admin to authorize resellers with a specified CODE/COMISSION
+// 3. Allows authorized resellers to get their earnings
+module suins::reseller {
+
+    use std::option::{Self, Option};
+    use std::string::{String};
+
+    use sui::table::{Self, Table};
+    use sui::object::{Self, UID};
+    use sui::balance::{Self, Balance};
+    use sui::sui::SUI;
+    use sui::tx_context::{TxContext};
+    use sui::transfer;
+    use sui::coin::{Self, Coin};
+
+    use suins::suins::{Self, SuiNS, AdminCap};
+
+    /// The specified reseller already exists.
+    const EAlreadyExists: u64 = 1;
+    /// The specified reseller doesn't exist.
+    const EResellerNotExists: u64 = 2;
+    /// The specified commission is invalid (not in range [1, 10_000])
+    const EInvalidComission: u64 = 3;
+
+    /// The ResellerCap, which allows access to withdraw funds as a reseller.
+    /// We can only have 1 of these per authorized reseller.
+    struct ResellerCap has key, store {
+        id: UID,
+        for: String
+    }
+
+    /// The configuration for each reseller. Each reseller has:
+    /// `balance`: It keeps the commission fees
+    /// `enabled`: Whether this reseller code is still enabled
+    /// `commission` The commission percentage (2 digit precision)
+    struct ResellerConfig has store {
+        enabled: bool,
+        balance: Balance<SUI>,
+        // 10_000 = 100% | 9_000 -> 99.99%
+        commission: u16 // [1, 10_000]. Works with 2 digit precision.
+    }
+
+    /// The shared object that holds information about the resellers.
+    struct ResellerBoard has key, store { 
+        id: UID,
+        resellers: Table<String, ResellerConfig>
+    }
+
+    /// Shares the reseller board    
+    fun init(ctx: &mut TxContext) {
+        transfer::public_share_object(ResellerBoard {
+            id: object::new(ctx),
+            resellers: table::new(ctx)
+        })
+    }
+
+    /// Authorizes a new reseller in the system as an admin
+    public fun authorize(self: &mut ResellerBoard, _: &AdminCap, reseller: String, commission: u16, ctx: &mut TxContext): ResellerCap {
+        validate_commission(commission);
+
+        // validate that this reseller doesn't already exist.
+        assert!(!table::contains(&self.resellers, reseller), EAlreadyExists);
+
+        table::add(&mut self.resellers, reseller, ResellerConfig {
+            enabled: true,
+            balance: balance::zero(),
+            commission
+        });
+
+        ResellerCap {
+            id: object::new(ctx),
+            for: reseller
+        }
+    }
+
+    /// Withdraw all commissions earned as a reseller.
+    public fun withdraw(self: &mut ResellerBoard, cap: &ResellerCap, ctx: &mut TxContext): Coin<SUI> {
+        assert!(table::contains(&self.resellers, cap.for), EResellerNotExists);
+
+        let config = table::borrow_mut(&mut self.resellers, cap.for);
+        let total = balance::value(&config.balance);
+        coin::take(&mut config.balance, total, ctx)
+    }
+
+    /// Handles a payment for reselling system. 
+    /// Now, on our authorized modules, instead of calling `app_add_balance`,
+    /// we can call this payment handler instead, which supports reseller codes.
+    /// This module on its own has no authorization, it just proxies the authorization from an authorized one.
+    /// `A` must be an authorized app on its own. This just proxies the payment.
+    public fun handle_payment<A: drop>(
+        app: A,
+        self: &mut ResellerBoard,
+        suins: &mut SuiNS,
+        payment: Coin<SUI>,
+        reseller: Option<String>,
+        ctx: &mut TxContext
+    ) {
+        // If we have a reseller code, we take the commission fee.
+        if(option::is_some(&reseller)){
+            let code = *option::borrow(&reseller);
+            assert!(table::contains(&self.resellers, code), EResellerNotExists);
+
+            let settings = table::borrow_mut(&mut self.resellers, code);
+            let value = coin::value(&payment);
+            let commission = coin::split(&mut payment, calculate_comission_fee(value, settings.commission), ctx);
+
+            balance::join(&mut settings.balance, coin::into_balance(commission));
+        };
+        suins::app_add_balance(app, suins, coin::into_balance(payment))
+    }
+
+
+    /// Allows to set the enabled (enable or disable) a reseller code.
+    public fun set_enabled(self: &mut ResellerBoard, _: &AdminCap, reseller: String, enabled: bool) {
+
+        assert!(table::contains(&self.resellers, reseller), EResellerNotExists);
+
+        let config = table::borrow_mut(&mut self.resellers, reseller);
+
+        config.enabled = enabled
+    }
+
+
+    /// Calculates the commission fee due to payment to the reseller.
+    public fun calculate_comission_fee(payment: u64, commission: u16): u64 {
+        let amount = (((payment as u128) * (commission as u128) / 10_000) as u64);
+        amount
+    }
+
+    /// Valiates the commission is valid (is in range [1, 10_000])
+    fun validate_commission(commission: u16) {
+        assert!(commission > 0 && commission <= 10_000, EInvalidComission)
+    }
+}

--- a/packages/suins/tests/reseller_tests.move
+++ b/packages/suins/tests/reseller_tests.move
@@ -1,0 +1,9 @@
+
+
+#[test_only]
+
+module suins::reseller_tests {
+    
+
+    use suins::reseller::{Self, ResellerBoard};
+}

--- a/packages/suins/tests/reseller_tests.move
+++ b/packages/suins/tests/reseller_tests.move
@@ -1,9 +1,242 @@
-
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-
 module suins::reseller_tests {
-    
+    use std::option::{Self, Option};
+    use std::string::{String, utf8};
 
-    use suins::reseller::{Self, ResellerBoard};
+    use sui::test_scenario::{Self as ts, Scenario, ctx};
+    use sui::transfer;
+    use sui::coin::{Self, Coin};
+    use sui::sui::SUI;
+
+    use suins::suins::{Self, SuiNS};
+    use suins::reseller::{Self, ResellerBoard, ResellerCap};
+
+    /// A test app to use for using the reseller system.
+    struct TestApp has drop {}
+
+    const ADMIN_ADDRESS: address = @0x1;
+    const USER: address = @0x2;
+    const RESELLER: address = @0x3;
+    const SALE_PRICE: u64 = 100_000_000;
+
+    #[test]
+    /// Pay a regular amount without reseller code (option::none()) and 
+    /// make sure the suins got all the coin balance.
+    fun test_no_code_handling_success() {
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+
+        pay_handler<TestApp>(TestApp {}, scenario, 100_000_000, option::none(), USER);
+
+        {
+            ts::next_tx(scenario, USER);
+            let suins = ts::take_shared<SuiNS>(scenario);
+            assert!(suins::total_balance(&suins) == 100_000_000, 0);
+            ts::return_shared(suins);
+        };
+
+        ts::end(scenario_val);
+    }
+
+    #[test]
+    /// Tests a full successful flow where:
+    /// 1. Authorize a reseller
+    /// 2. Process a payment and verify that reseller got the expect amount
+    fun test_authorized_reseller_success() {
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+
+        authorize_reseller(scenario, get_reseller_code(), 10_00, RESELLER);
+
+        pay_handler<TestApp>(TestApp {}, scenario, 100_000_000, option::some(get_reseller_code()), USER);
+        // validate that the SUINS registry has got 90% of the funds
+        assert_suins_balance(scenario, 90_000_000);
+        // Validate that the RESELLER can withdraw profits (and that should be 10% so 10_000_000 in our example here)
+        assert_reseller_withdraw_balance(scenario, RESELLER, 10_000_000);
+
+        ts::end(scenario_val);
+    }
+
+    #[test]
+    /// Tests that the rate changes successfully from admin.
+    fun test_rate_change_success() {
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+
+        authorize_reseller(scenario, get_reseller_code(), 10_00, RESELLER);
+        pay_handler<TestApp>(TestApp {}, scenario, SALE_PRICE, option::some(get_reseller_code()), USER);
+        // validate that the SUINS registry has got 90% of the funds
+        assert_suins_balance(scenario, 90_000_000); // (90_000_000 -> 90% of SALE_PRICE)
+        // Validate that the RESELLER can withdraw profits (and that should be 10% so 10_000_000 in our example here)
+        assert_reseller_withdraw_balance(scenario, RESELLER, 10_000_000); // (10_000_000 -> 10% of SALE_PRICE)
+
+        // change commission to 20% now.
+        set_reseller_commission(scenario, get_reseller_code(), 20_00);
+        pay_handler<TestApp>(TestApp {}, scenario, SALE_PRICE, option::some(get_reseller_code()), USER);
+        // validate that the SUINS registry has got 80% of the funds
+        assert_suins_balance(scenario, 90_000_000 + 80_000_000);
+        // Validate that the RESELLER can withdraw profits (and that should be 10% so 10_000_000 in our example here)
+        assert_reseller_withdraw_balance(scenario, RESELLER, 20_000_000);
+
+        ts::end(scenario_val);
+    }
+
+    #[test, expected_failure(abort_code = suins::reseller::EAlreadyExists)]
+    fun test_double_authorization_failure() {
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+
+        authorize_reseller(scenario, get_reseller_code(), 10_00, RESELLER);
+        authorize_reseller(scenario, get_reseller_code(), 15_00, RESELLER);
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = suins::reseller::EInvalidComission)]
+    fun test_invalid_percentage_failure() {
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+
+        authorize_reseller(scenario, get_reseller_code(), 10_001, RESELLER);
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = suins::reseller::EResellerNotExists)]
+    fun try_to_claim_with_invalid_reseller_failure() {
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+
+       pay_handler<TestApp>(TestApp {}, scenario, SALE_PRICE, option::some(utf8(b"RANDOM_NON_EXISTING_RESELLER")), USER);
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = suins::reseller::EResellerDisabled)]
+    fun try_to_pay_with_unauthorized_reseller_failure() {
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+
+        authorize_reseller(scenario, get_reseller_code(), 10_00, RESELLER);
+        disable_reseller(scenario, get_reseller_code());
+        pay_handler<TestApp>(TestApp {}, scenario, SALE_PRICE, option::some(get_reseller_code()), USER);
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = suins::reseller::EResellerNotExists)]
+    fun try_to_disable_non_existing_reseller_failure(){
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+        disable_reseller(scenario, get_reseller_code());
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = suins::reseller::EResellerNotExists)]
+    fun try_to_change_rate_to_non_existing_reseller_failure(){
+        let scenario_val = setup();
+        let scenario = &mut scenario_val;
+        set_reseller_commission(scenario, get_reseller_code(), 20_00);
+
+        abort 1337
+    }
+
+
+    ///
+    /// ===== HELPERS =====
+    /// 
+    fun get_reseller_code(): String {
+        utf8(b"RESELLER")
+    }
+
+    fun setup (): Scenario {
+        let scenario_val = ts::begin(ADMIN_ADDRESS);
+        let scenario = &mut scenario_val;
+        {
+            ts::next_tx(scenario, ADMIN_ADDRESS);
+
+            let suins = suins::init_for_testing(ctx(scenario));
+            reseller::init_for_testing(ctx(scenario));
+            suins::authorize_app_for_testing<TestApp>(&mut suins);
+            suins::share_for_testing(suins);
+        };
+
+        scenario_val
+    }
+
+    fun authorize_reseller(scenario: &mut Scenario, reseller: String, commission: u16, user: address) {
+        ts::next_tx(scenario, ADMIN_ADDRESS);
+
+        let app = ts::take_shared<ResellerBoard>(scenario);
+        let admin_cap = suins::create_admin_cap_for_testing(ctx(scenario));
+
+        let cap = reseller::authorize(&mut app, &admin_cap, reseller, commission, ctx(scenario));
+        transfer::public_transfer(cap, user);
+
+        suins::burn_admin_cap_for_testing(admin_cap);
+        ts::return_shared(app);
+    }
+
+    fun disable_reseller(scenario: &mut Scenario, reseller: String) {
+        ts::next_tx(scenario, ADMIN_ADDRESS);
+
+        let app = ts::take_shared<ResellerBoard>(scenario);
+        let admin_cap = suins::create_admin_cap_for_testing(ctx(scenario));
+        reseller::set_enabled(&mut app, &admin_cap, reseller, false);
+
+        suins::burn_admin_cap_for_testing(admin_cap);
+        ts::return_shared(app);
+    }
+
+    fun set_reseller_commission(scenario: &mut Scenario, reseller: String, commission: u16){
+        ts::next_tx(scenario, ADMIN_ADDRESS);
+
+        let app = ts::take_shared<ResellerBoard>(scenario);
+        let admin_cap = suins::create_admin_cap_for_testing(ctx(scenario));
+        reseller::set_commission(&mut app, &admin_cap, reseller, commission);
+
+        suins::burn_admin_cap_for_testing(admin_cap);
+        ts::return_shared(app);
+    }
+
+    fun pay_handler<App: drop>(app: App, scenario: &mut Scenario, amount: u64, code: Option<String>, user: address) {
+        ts::next_tx(scenario, user);
+
+        let suins = ts::take_shared<SuiNS>(scenario);
+        let board = ts::take_shared<ResellerBoard>(scenario);
+
+        let payment: Coin<SUI> = coin::mint_for_testing(amount, ctx(scenario));
+
+        reseller::handle_payment(app, &mut board, &mut suins, payment, code, ctx(scenario));
+
+        ts::return_shared(suins);
+        ts::return_shared(board);
+    }
+
+    fun assert_suins_balance(scenario: &mut Scenario, value: u64) {
+        ts::next_tx(scenario, USER);
+        let suins = ts::take_shared<SuiNS>(scenario);
+
+        assert!(suins::total_balance(&suins) == value, 0);
+        ts::return_shared(suins);
+    }
+
+    fun assert_reseller_withdraw_balance(scenario: &mut Scenario, reseller: address, value: u64) {
+
+        ts::next_tx(scenario, reseller);
+        let cap = ts::take_from_sender<ResellerCap>(scenario);
+        let board = ts::take_shared<ResellerBoard>(scenario);
+
+        let coin = reseller::withdraw(&mut board, &cap, ctx(scenario));
+
+        assert!(coin::value(&coin) == value, 1);
+        transfer::public_transfer(coin, reseller);
+
+        ts::return_shared(board);
+        ts::return_to_sender(scenario, cap);
+    }
 }


### PR DESCRIPTION
This module comes with the reseller system. 

It allows us to optionally add a reseller fee in each transaction. The Admin can generate reseller codes for partners, and each partner can collect their own fees using the `ResellerCap` that can be transferred to them. 

The module on its own could work as a separate package, but I decided to introduce it in the main package because, If we upgrade `suins`, we'd need to update the `reseller` package, and for the `registration` packages to pick up the changes, that would also need to be upgraded (we're looking at a chain of upgrades, that could be limited to a smaller depth).  And we are, certain, that a lot of packages will be calling this reselling code (direct registration, renewals, coupon system, possibly discount/object system and so on).

I am not rigid on this, I am curious to discuss it.

I've also introduced how it would look on the registration package we have. **This wouldn't be a package upgrade, we would deauthorize the old one and re-publish!** 
