### PR TITLE
Adds reserved list for SuiNS (reserved + offensive)

### DIFF
--- a/packages/reserved/Move.toml
+++ b/packages/reserved/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "reserved"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
+
+[addresses]
+reserved = "0x0"

--- a/packages/reserved/sources/reserved_names.move
+++ b/packages/reserved/sources/reserved_names.move
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A list that can be used to prevent registrations with our reserved names list.
+/// 
+/// Can be used in any SuiNS registration package (optionally, as we might have an admin registration that skips these checks).
+/// Can also be used in subdomain registration (checks on the offensive table)
+module reserved::reserved_names {
+    use std::vector;
+    use std::string::{String};
+
+    use sui::object::{Self, UID};
+    use sui::tx_context::{TxContext, sender};
+    use sui::table::{Self, Table};
+    use sui::transfer;
+
+    /// == Error Codes ==
+    /// No names in the passed list
+    const ENoWordsInList: u64 = 1;
+    /// The name is in the reserved list so it can't be used.
+    const EReservedName: u64 = 2;
+    /// The name is in the offensive list so it can't be used.
+    const EOffensiveName: u64 = 3;
+
+    /// A struct that holds the ReservedList list.
+    /// 
+    /// We hold two different tables:
+    /// 1. Reserved: Names (SLD) that our partner's hold and we don't want to share.
+    /// 2. Offensive: Names that are offensive and we don't want people to use. This one will be checked on subdomains too.
+    struct ReservedList has key {
+        id: UID,
+        reserved: Table<String, bool>,
+        offensive: Table<String, bool>
+    }
+
+    /// The Cap to add/remove words from the list.
+    /// We are generating a new Cap to decouple from SuiNS (skip dependency on main app's AdminCap) and to be able to use
+    /// in a 1 out of 6 multisig address, to make additions / removals faster.
+    struct ReservedListCap has key, store {
+        id: UID
+    }
+
+    /// Share the empty list & transfer cap to the admin.
+    fun init(ctx: &mut TxContext) {
+        transfer::share_object(ReservedList {
+            id: object::new(ctx),
+            reserved: table::new(ctx),
+            offensive: table::new(ctx)
+        });
+
+        transfer::transfer(ReservedListCap {
+            id: object::new(ctx)
+        }, sender(ctx));
+    }
+
+
+    /// == Public functionality == 
+    ///
+    /// An easy assertion that the word is not in the resered names list.
+    public fun assert_is_not_reserved_name(self: &ReservedList, word: String) {
+        assert!(!is_reserved_name(self, word), EReservedName);
+    }
+
+    /// Boolean check for reserved names to use in custom cases.
+    public fun is_reserved_name(self: &ReservedList, word: String): bool {
+        table::contains(&self.reserved, word)
+    }
+
+    /// An easy assertion that the word is not in the offensive names list.
+    public fun assert_is_not_offensive_name(self: &ReservedList, word: String) {
+        assert!(!is_offensive_name(self, word), EOffensiveName);
+    }
+
+    public fun is_offensive_name(self: &ReservedList, word: String): bool {
+        table::contains(&self.offensive, word)
+    }
+
+    /// == Admin functionality == 
+    /// 
+    /// Add a list of reserved names to the list as admin.
+    public fun add_reserved_names(self: &mut ReservedList, _: &ReservedListCap, words: vector<String>) {
+        internal_add_names_to_list(&mut self.reserved, words);
+    }
+
+    /// Add a list of offensive names to the list as admin.
+    public fun add_offensive_names(self: &mut ReservedList, _: &ReservedListCap, words: vector<String>) {
+        internal_add_names_to_list(&mut self.offensive, words);
+    }
+
+    /// Remove a list of words from the reserved names list.
+    public fun remove_reserved_names(self: &mut ReservedList, _: &ReservedListCap, words: vector<String>) {
+        internal_remove_names_from_list(&mut self.reserved, words);
+    }
+
+    /// Remove a list of words from the list as admin.
+    public fun remove_offensive_names(self: &mut ReservedList, _: &ReservedListCap, words: vector<String>) {
+        internal_remove_names_from_list(&mut self.offensive, words);
+    }
+
+    /// Internal helper to batch add words to a table.
+    fun internal_add_names_to_list(table: &mut Table<String, bool>, words: vector<String>) {
+        assert!(vector::length(&words) > 0, ENoWordsInList);
+
+        let i = vector::length(&words);
+
+        while (i > 0) {
+            i = i - 1;
+            let word = *vector::borrow(&words, i);
+            table::add(table, word, true);
+        };
+    }
+
+    /// Internal helper to remove words from a table.
+    fun internal_remove_names_from_list(table: &mut Table<String, bool>, words: vector<String>) {
+        assert!(vector::length(&words) > 0, ENoWordsInList);
+
+        let i = vector::length(&words);
+
+        while (i > 0) {
+            i = i - 1;
+            let word = *vector::borrow(&words, i);
+            table::remove(table, word);
+        };
+    }
+
+    #[test_only]
+    public fun list_for_testing(ctx: &mut TxContext): ReservedList {
+        ReservedList {
+            id: object::new(ctx),
+            reserved: table::new(ctx),
+            offensive: table::new(ctx)
+        }
+    }
+
+    #[test_only]
+    public fun cap_for_testing(ctx: &mut TxContext): ReservedListCap {
+        ReservedListCap {
+            id: object::new(ctx)
+        }
+    }
+
+    #[test_only]
+    public fun burn_list_for_testing(list: ReservedList){
+        let ReservedList { reserved, offensive, id } = list;
+        table::drop(reserved);
+        table::drop(offensive);
+        object::delete(id);
+    }
+
+    #[test_only]
+    public fun burn_cap_for_testing(cap: ReservedListCap){
+        let ReservedListCap { id } = cap;
+        object::delete(id);
+    }
+}

--- a/packages/reserved/tests/reserved_names_tests.move
+++ b/packages/reserved/tests/reserved_names_tests.move
@@ -1,0 +1,102 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module reserved::reserved_names_tests {
+    use std::vector;
+    use std::string::{utf8, String};
+
+    use sui::tx_context::{TxContext};
+    use sui::test_scenario::{Self as ts, ctx};
+
+    use reserved::reserved_names::{Self, ReservedList, ReservedListCap};
+
+    const ADDR: address = @0x0;
+
+    fun prepare_data(ctx: &mut TxContext): (ReservedList, ReservedListCap) {
+        let names = reserved_names::list_for_testing(ctx);
+        let cap = reserved_names::cap_for_testing(ctx);
+
+        reserved_names::add_reserved_names(&mut names, &cap, some_reserved_names());
+        reserved_names::add_offensive_names(&mut names, &cap, some_offensive_names());
+
+        (names, cap)
+    }
+
+    fun wrap(list: ReservedList, cap: ReservedListCap) {
+        reserved_names::burn_cap_for_testing(cap);
+        reserved_names::burn_list_for_testing(list);
+    }
+
+    fun some_reserved_names(): vector<String> {
+        let vec: vector<String> = vector::empty();
+
+        vector::push_back(&mut vec, utf8(b"test"));
+        vector::push_back(&mut vec, utf8(b"test2"));
+        vector::push_back(&mut vec, utf8(b"test3"));
+        vec
+    }
+
+    fun some_offensive_names(): vector<String> {
+        let vec: vector<String> = vector::empty();
+        vector::push_back(&mut vec, utf8(b"bad_test"));
+        vector::push_back(&mut vec, utf8(b"bad_test2"));
+        vector::push_back(&mut vec, utf8(b"bad_test3"));
+        vec
+    }
+
+    #[test]
+    fun test() {
+        let scenario_val = ts::begin(ADDR);
+        let scenario = &mut scenario_val;
+
+        let (names, cap) = prepare_data(ctx(scenario));
+    
+        assert!(reserved_names::is_reserved_name(&names, utf8(b"test")), 0);
+        assert!(!reserved_names::is_reserved_name(&names, utf8(b"non")), 0);
+
+        // remove a name for test
+
+        reserved_names::remove_reserved_names(&mut names, &cap, vector[utf8(b"test")]);
+         assert!(!reserved_names::is_reserved_name(&names, utf8(b"test")), 0);
+         
+        wrap(names, cap);
+        ts::end(scenario_val);
+    }
+
+    #[test, expected_failure(abort_code = reserved::reserved_names::EOffensiveName)]
+    fun test_offensive_failure(){
+        let scenario_val = ts::begin(ADDR);
+        let scenario = &mut scenario_val;
+        
+        let (names, _cap) = prepare_data(ctx(scenario));
+
+        reserved_names::assert_is_not_offensive_name(&names, utf8(b"bad_test"));
+
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code = reserved::reserved_names::EReservedName)]
+    fun test_reserved_failure(){
+        let scenario_val = ts::begin(ADDR);
+        let scenario = &mut scenario_val;
+        
+        let (names, _cap) = prepare_data(ctx(scenario));
+
+        reserved_names::assert_is_not_reserved_name(&names, utf8(b"test"));
+
+        abort 1337
+    }
+
+
+    #[test, expected_failure(abort_code = reserved::reserved_names::ENoWordsInList)]
+    fun test_empty_addition_failure(){
+        let scenario_val = ts::begin(ADDR);
+        let scenario = &mut scenario_val;
+        
+        let (names, cap) = prepare_data(ctx(scenario));
+
+        reserved_names::add_reserved_names(&mut names, &cap, vector[]);
+
+        abort 1337
+    }
+}


### PR DESCRIPTION
We add a reserved list to avoid having to book the domain names ourselves (and skip the risk of forgetting to renew them, which is currently there).

**The reserved list is split in two parts:**
1. Reserved names: Those are mysten names, partner names, SP2000 company names. Pretty much all names that are ok and valid, but shouldn't be registered by anyone outside mysten.
2. Offensive names: Those are the curse words which we don't want to be registered in ANY way. This particular list will be checked against for subdomains too.

I have an extra PR (#37) that adapts all our existing applications to use the reserved list on registration.