### PR TITLE
[Subdomains 4/n] Adds reserved/blocked list names

### DIFF
--- a/packages/denylist/Move.toml
+++ b/packages/denylist/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "denylist"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+suins = { local = "../suins" }
+
+[addresses]
+denylist = "0x0"

--- a/packages/denylist/sources/denylist.move
+++ b/packages/denylist/sources/denylist.move
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module denylist::denylist {
+    use std::string::String;
+    use std::vector;
+
+    use sui::tx_context::{TxContext};
+    use sui::table::{Self, Table};
+    
+    use suins::suins::{Self, AdminCap, SuiNS};
+
+    /// No names in the passed list
+    const ENoWordsInList: u64 = 1;
+
+    /// A wrapper that holds the reserved and blocked names.
+    struct Denylist has store {
+        // The list of reserved names. 
+        // Our public SLD registrations will be checking against it.
+        reserved: Table<String, bool>,
+        // The list of blocked names.
+        // Subdomains + registrations will be checking against.
+        blocked: Table<String, bool>,
+    }
+
+    /// The authorization for the denylist registry.
+    struct DenyListAuth has drop {}
+
+    public fun setup(suins: &mut SuiNS, cap: &AdminCap, ctx: &mut TxContext) {
+        suins::add_registry(cap, suins, Denylist {
+            reserved: table::new(ctx),
+            blocked: table::new(ctx)
+        });
+    }
+
+    /// Check for a reserved name
+    public fun is_reserved_name(suins: &SuiNS, name: String): bool {
+        table::contains(&denylist(suins).reserved, name)
+    }
+
+    /// Checks for a blocked name.
+    public fun is_blocked_name(suins: &SuiNS, name: String): bool {
+        table::contains(&denylist(suins).blocked, name)
+    }
+
+    /// Add a list of reserved names to the list as admin.
+    public fun add_reserved_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+        internal_add_names_to_list(&mut denylist_mut(suins).reserved, words);
+    }
+
+    /// Add a list of offensive names to the list as admin.
+    public fun add_blocked_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+        internal_add_names_to_list(&mut denylist_mut(suins).blocked, words);
+    }
+
+    /// Remove a list of words from the reserved names list.
+    public fun remove_reserved_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+        internal_remove_names_from_list(&mut denylist_mut(suins).reserved, words);
+    }
+
+    /// Remove a list of words from the list as admin.
+    public fun remove_blocked_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+        internal_remove_names_from_list(&mut denylist_mut(suins).blocked, words);
+    }
+
+    /// Get immutable access to the registry.
+    fun denylist(suins: &SuiNS): &Denylist {
+        suins::registry(suins)
+    }
+
+    /// Internal helper to get access to the BlockedNames object
+    fun denylist_mut(suins: &mut SuiNS): &mut Denylist {
+        suins::app_registry_mut<DenyListAuth, Denylist>(DenyListAuth {}, suins)
+    }
+
+    /// Internal helper to batch add words to a table.
+    fun internal_add_names_to_list(table: &mut Table<String, bool>, words: vector<String>) {
+        assert!(vector::length(&words) > 0, ENoWordsInList);
+
+        let i = vector::length(&words);
+
+        while (i > 0) {
+            i = i - 1;
+            let word = *vector::borrow(&words, i);
+            table::add(table, word, true);
+        };
+    }
+
+    /// Internal helper to remove words from a table.
+    fun internal_remove_names_from_list(table: &mut Table<String, bool>, words: vector<String>) {
+        assert!(vector::length(&words) > 0, ENoWordsInList);
+
+        let i = vector::length(&words);
+
+        while (i > 0) {
+            i = i - 1;
+            let word = *vector::borrow(&words, i);
+            table::remove(table, word);
+        };
+    }
+
+    #[test_only]
+    public fun new_for_testing(ctx: &mut TxContext): Denylist {
+        Denylist {
+            reserved: table::new(ctx),
+            blocked: table::new(ctx)
+        }
+    }
+}

--- a/packages/denylist/tests/denylist_tests.move
+++ b/packages/denylist/tests/denylist_tests.move
@@ -1,0 +1,158 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module denylist::denylist_tests {
+    use std::vector;
+    use std::string::{utf8, String};
+
+    use sui::test_scenario::{Self as ts, ctx, Scenario};
+
+    use suins::suins::{Self, SuiNS};
+
+    use denylist::denylist::{Self, DenyListAuth};
+
+    const ADDR: address = @0x0;
+
+    #[test]
+    fun test() {
+        let scenario_val = test_init();
+        let scenario = &mut scenario_val;
+
+        ts::next_tx(scenario, ADDR);
+        let suins = ts::take_shared<SuiNS>(scenario);
+        let cap = suins::create_admin_cap_for_testing(ctx(scenario));
+
+        denylist::add_reserved_names(&mut suins, &cap, some_reserved_names());
+        denylist::add_blocked_names(&mut suins, &cap, some_offensive_names());
+
+
+        assert!(denylist::is_reserved_name(&suins, utf8(b"test")), 0);
+        assert!(denylist::is_reserved_name(&suins, utf8(b"test2")), 0);
+    
+        assert!(denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
+
+        assert!(!denylist::is_blocked_name(&suins, utf8(b"example")), 0);
+
+        assert!(!denylist::is_reserved_name(&suins, utf8(b"example")), 0);
+
+        suins::burn_admin_cap_for_testing(cap);
+
+        ts::return_shared(suins);
+        ts::end(scenario_val);
+    }
+
+    #[test, expected_failure(abort_code = denylist::denylist::ENoWordsInList)]
+    fun test_empty_addition_failure(){
+        let scenario_val = test_init();
+        let scenario = &mut scenario_val;
+
+        ts::next_tx(scenario, ADDR);
+        let suins = ts::take_shared<SuiNS>(scenario);
+        let cap = suins::create_admin_cap_for_testing(ctx(scenario));
+
+        denylist::add_reserved_names(&mut suins, &cap, vector[]);
+
+        abort 1337
+    }
+
+    // coverage.. :) 
+    #[test, expected_failure(abort_code = denylist::denylist::ENoWordsInList)]
+    fun test_empty_addition_blocked_failure(){
+        let scenario_val = test_init();
+        let scenario = &mut scenario_val;
+
+        ts::next_tx(scenario, ADDR);
+        let suins = ts::take_shared<SuiNS>(scenario);
+        let cap = suins::create_admin_cap_for_testing(ctx(scenario));
+
+        denylist::add_blocked_names(&mut suins, &cap, vector[]);
+
+        abort 1337
+    }
+
+    #[test]
+    fun remove_blocked_word(){
+        let scenario_val = test_init();
+        let scenario = &mut scenario_val;
+
+        ts::next_tx(scenario, ADDR);
+        let suins = ts::take_shared<SuiNS>(scenario);
+        let cap = suins::create_admin_cap_for_testing(ctx(scenario));
+
+        denylist::add_blocked_names(&mut suins, &cap, some_offensive_names());
+
+        assert!(denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
+
+        denylist::remove_blocked_names(&mut suins, &cap, vector[utf8(b"bad_test")]);
+
+        assert!(!denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
+
+        suins::burn_admin_cap_for_testing(cap);
+
+        ts::return_shared(suins);
+        ts::end(scenario_val);
+    }
+
+    #[test]
+    fun remove_reserved_word(){
+        let scenario_val = test_init();
+        let scenario = &mut scenario_val;
+
+        ts::next_tx(scenario, ADDR);
+        let suins = ts::take_shared<SuiNS>(scenario);
+        let cap = suins::create_admin_cap_for_testing(ctx(scenario));
+
+        denylist::add_reserved_names(&mut suins, &cap, some_reserved_names());
+
+        let name = utf8(b"test");
+
+        assert!(denylist::is_reserved_name(&suins, name), 0);
+
+        denylist::remove_reserved_names(&mut suins, &cap, vector[name]);
+
+        assert!(!denylist::is_reserved_name(&suins, name), 0);
+
+        suins::burn_admin_cap_for_testing(cap);
+
+        ts::return_shared(suins);
+        ts::end(scenario_val);
+    }
+
+    // data preparation
+
+    public fun test_init(): (Scenario) {
+        let scenario = ts::begin(ADDR);
+        {
+            ts::next_tx(&mut scenario, ADDR);
+
+            let (suins, cap) = suins::new_for_testing(ctx(&mut scenario));
+
+            suins::authorize_app_for_testing<DenyListAuth>(&mut suins);
+
+            denylist::setup(&mut suins, &cap, ctx(&mut scenario));
+
+            suins::share_for_testing(suins);
+        
+            suins::burn_admin_cap_for_testing(cap);
+        };
+
+        scenario
+    }
+
+    fun some_reserved_names(): vector<String> {
+        let vec: vector<String> = vector::empty();
+
+        vector::push_back(&mut vec, utf8(b"test"));
+        vector::push_back(&mut vec, utf8(b"test2"));
+        vector::push_back(&mut vec, utf8(b"test3"));
+        vec
+    }
+
+    fun some_offensive_names(): vector<String> {
+        let vec: vector<String> = vector::empty();
+        vector::push_back(&mut vec, utf8(b"bad_test"));
+        vector::push_back(&mut vec, utf8(b"bad_test2"));
+        vector::push_back(&mut vec, utf8(b"bad_test3"));
+        vec
+    }
+}

--- a/packages/subdomains/Move.toml
+++ b/packages/subdomains/Move.toml
@@ -11,6 +11,7 @@ version = "0.0.1"
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet", override=true }
 suins = { local = "../suins" }
+denylist = { local = "../denylist" }
 
 [addresses]
 


### PR DESCRIPTION
Adds the reserved + blocked lists for SuiNS.

These lists will be used to avoid doing a registration + renewal for many names that we initially purchased on our main SuiNS address. 

For subdomains, we only check against blocked list, which is a list of cursing words that we don't wanna have in our network. Adapts subdomains PR to also check against the `blocked` name list.