### PR TITLE
Switch to using sui instead of sui-test-validator

### DIFF
--- a/.github/workflows/sdk_test.yml
+++ b/.github/workflows/sdk_test.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Prepare local network & run SDK tests
         run: |
-          ./sui-test-validator --epoch-duration-ms 300000 > /dev/null 2>&1 & cd sdk && VITE_SUI_BIN="../sui" pnpm test:e2e
+          ./sui --with-faucet --force-regenesis --epoch-duration-ms 300000 > /dev/null 2>&1 & cd sdk && VITE_SUI_BIN="../sui" pnpm test:e2e

--- a/.github/workflows/sdk_test.yml
+++ b/.github/workflows/sdk_test.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Prepare local network & run SDK tests
         run: |
-          ./sui --with-faucet --force-regenesis --epoch-duration-ms 300000 > /dev/null 2>&1 & cd sdk && VITE_SUI_BIN="../sui" pnpm test:e2e
+          ./sui start --with-faucet --force-regenesis --epoch-duration-ms 300000 > /dev/null 2>&1 & cd sdk && VITE_SUI_BIN="../sui" pnpm test:e2e

--- a/sdk/information.md
+++ b/sdk/information.md
@@ -4,7 +4,7 @@ To run e2e tests, you need to first run a local sui network with the simplest se
 You'd need the sui repository installed, and you could run the following command on the `sui` root folder.
 
 ```sh
-cargo build --bin sui-test-validator --bin sui --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui-test-validator -- --epoch-duration-ms 300000
+cargo build --bin sui --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui -- start --with-faucet --force-regenesis --epoch-duration-ms 300000
 ```
 
 And then you can execute the tests (using a new terminal) by running:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -38,7 +38,7 @@
 		"lint": "pnpm run eslint:check && pnpm run prettier:check",
 		"lint:fix": "pnpm run eslint:fix && pnpm run prettier:fix",
 		"test:e2e": "wait-on http://127.0.0.1:9123 -l --timeout 120000 && vitest run",
-		"prepare:e2e": "cargo build --bin sui-test-validator --bin sui --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui-test-validator -- --epoch-duration-ms 300000"
+		"prepare:e2e": "cargo build --bin sui --profile dev && cross-env RUST_LOG=info,sui=error,anemo_tower=warn,consensus=off cargo run --bin sui -- start --with-faucet --force-regenesis --epoch-duration-ms 300000"
 	},
 	"engines": {
 		"node": ">=16"


### PR DESCRIPTION
PR #18204 from main `sui` repository integrated `sui-test-validator` into `sui`. To use the usual `sui-test-validator`, one needs to use now `sui start`.