### PR TITLE
fix(domain): `Domain::sld` comment

### DIFF
--- a/packages/suins/sources/domain.move
+++ b/packages/suins/sources/domain.move
@@ -84,7 +84,7 @@ public fun tld(self: &Domain): &String {
 
 /// Returns the SLD (Second-Level Domain) of a `Domain`.
 ///
-/// "name.sui" -> "sui"
+/// "name.sui" -> "name"
 public fun sld(self: &Domain): &String {
     label(self, 1)
 }


### PR DESCRIPTION
Adjust the `Domain::sld` comment to return the correct label.