### PR TITLE
Clarify Dependency Directory Purpose in .gitignore

### DIFF
--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -38,7 +38,7 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
-# Dependency directories
+# Dependency directories (Node.js, JSPM)
 node_modules/
 jspm_packages/
 


### PR DESCRIPTION
Improve Documentation Clarity in .gitignore
File Modified: documentation/.gitignore

Updated the comment:
# Dependency directories to # Dependency directories (Node.js, JSPM).
This makes it clearer that the ignored directories relate specifically to Node.js and JSPM.
Reason for Change:

Helps new contributors understand why node_modules/ and jspm_packages/ are ignored.
Avoids confusion about which dependencies are being referenced.