### PR TITLE
[formatting] Formatting and license headers

### DIFF
--- a/.github/workflows/move-formatter.yml
+++ b/.github/workflows/move-formatter.yml
@@ -1,0 +1,23 @@
+name: Check Move formatting
+
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+
+env:
+  MOVE_PACKAGES_PATH: packages
+
+jobs:
+  prettier-move:
+    name: Check Move files formatting
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.MOVE_PACKAGES_PATH }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+      - run: npm i @mysten/prettier-plugin-move
+      - run: npx prettier-move -c **/*.move

--- a/.github/workflows/move_test.yml
+++ b/.github/workflows/move_test.yml
@@ -22,15 +22,36 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Homebrew
+      - name: Install Sui 1.43.1
         run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+          echo "Installing Sui 1.43.1..."
+          mkdir -p $HOME/sui-bin
 
-      - name: Install Sui using Homebrew
-        run: brew install sui
+          SUI_URL="https://github.com/MystenLabs/sui/releases/download/mainnet-v1.43.1/sui-mainnet-v1.43.1-macos-x86_64.tgz"
+          echo "Downloading Sui from $SUI_URL"
 
-      - name: Run move tests in all package subdirectories, with exclusions
+          # Use curl with fail flag and check response
+          HTTP_STATUS=$(curl -o sui.tar.gz -w "%{http_code}" -L $SUI_URL)
+
+          if [[ "$HTTP_STATUS" -ne 200 ]]; then
+            echo "Error: Failed to download Sui. HTTP Status: $HTTP_STATUS"
+            exit 1
+          fi
+
+          if ! file sui.tar.gz | grep -q "gzip compressed"; then
+            echo "Error: Downloaded file is not a valid tar.gz archive."
+            exit 1
+          fi
+
+          tar -xvzf sui.tar.gz -C $HOME/sui-bin
+          chmod +x $HOME/sui-bin/sui
+          echo "$HOME/sui-bin" >> $GITHUB_PATH
+          export PATH="$HOME/sui-bin:$PATH"
+
+          # Verify installation
+          sui --version
+
+      - name: Run Move tests in all package subdirectories, with exclusions
         run: |
           excluded_dirs=(day_one governance) # Define excluded directories as an array
           for dir in packages/*; do

--- a/packages/.prettierrc
+++ b/packages/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "printWidth": 100,
+    "tabWidth": 4,
+    "useModuleLabel": true,
+    "autoGroupImports": "package"
+}

--- a/packages/coupons/sources/coupon.move
+++ b/packages/coupons/sources/coupon.move
@@ -14,19 +14,14 @@ const EInvalidDiscountPercentage: u64 = 1;
 /// price or discount percentage
 /// - `value` is a u64 constant, which can be in the range of (0,100] for
 /// discount percentage, or any value > 0 for fixed price.
-public struct Coupon has copy, store, drop {
+public struct Coupon has copy, drop, store {
     kind: u8, // 0 -> Percentage Discount | 1 -> Fixed Discount
     amount: u64, // if type == 0, we need it to be between 0, 100. We only allow int style (not 0.5% discount).
     rules: CouponRules, // A list of base Rules for the coupon.
 }
 
 /// An internal function to create a coupon object.
-public(package) fun new(
-    kind: u8,
-    amount: u64,
-    rules: CouponRules,
-    _ctx: &mut TxContext,
-): Coupon {
+public(package) fun new(kind: u8, amount: u64, rules: CouponRules, _ctx: &mut TxContext): Coupon {
     rules::assert_is_valid_amount(kind, amount);
     rules::assert_is_valid_discount_type(kind);
     Coupon {
@@ -45,10 +40,7 @@ public(package) fun rules_mut(coupon: &mut Coupon): &mut CouponRules {
 }
 
 public(package) fun discount_percentage(coupon: &Coupon): u64 {
-    assert!(
-        coupon.amount > 0 && coupon.amount <= 100,
-        EInvalidDiscountPercentage,
-    );
+    assert!(coupon.amount > 0 && coupon.amount <= 100, EInvalidDiscountPercentage);
 
     coupon.amount
 }

--- a/packages/coupons/sources/coupon_house.move
+++ b/packages/coupons/sources/coupon_house.move
@@ -15,17 +15,14 @@
 /// to the registry.
 module coupons::coupon_house;
 
-use coupons::coupon::{Self, Coupon};
-use coupons::data::{Self, Data};
-use coupons::rules::CouponRules;
+use coupons::{coupon::{Self, Coupon}, data::{Self, Data}, rules::CouponRules};
 use std::string::String;
-use sui::clock::Clock;
-use sui::coin::Coin;
-use sui::dynamic_field as df;
-use sui::sui::SUI;
-use suins::payment::PaymentIntent;
-use suins::suins::{Self, AdminCap, SuiNS};
-use suins::suins_registration::SuinsRegistration;
+use sui::{clock::Clock, coin::Coin, dynamic_field as df, sui::SUI};
+use suins::{
+    payment::PaymentIntent,
+    suins::{Self, AdminCap, SuiNS},
+    suins_registration::SuinsRegistration
+};
 
 /// An app that's not authorized tries to access private data.
 const EAppNotAuthorized: u64 = 1;
@@ -46,7 +43,7 @@ public struct CouponsApp has drop {}
 
 /// Authorization Key for secondary apps (e.g. Discord) connected to this
 /// module.
-public struct AppKey<phantom A: drop> has copy, store, drop {}
+public struct AppKey<phantom A: drop> has copy, drop, store {}
 
 /// The CouponHouse Shared Object which holds a table of coupon codes available
 /// for claim.
@@ -79,10 +76,7 @@ public fun apply_coupon(
     let coupon_house = coupon_house_mut(suins);
 
     // Validate that specified coupon is valid.
-    assert!(
-        coupon_house.data.coupons().contains(coupon_code),
-        ECouponNotExists,
-    );
+    assert!(coupon_house.data.coupons().contains(coupon_code), ECouponNotExists);
 
     // Borrow coupon from the table.
     let coupon: &mut Coupon = &mut coupon_house.data.coupons_mut()[coupon_code];
@@ -105,9 +99,7 @@ public fun apply_coupon(
     // 4. Validate the coupon hasn't expired (Based on clock)
     coupon.rules().assert_coupon_is_not_expired(clock);
     // 5. Validate years are valid for the coupon.
-    coupon
-        .rules()
-        .assert_coupon_valid_for_domain_years(intent.request_data().years());
+    coupon.rules().assert_coupon_valid_for_domain_years(intent.request_data().years());
 
     // Clean up our registry by removing the coupon if no more available claims!
     if (!coupon.rules().has_available_claims()) {
@@ -138,11 +130,7 @@ public fun register_with_coupon(
 }
 
 #[deprecated]
-public fun calculate_sale_price(
-    _suins: &SuiNS,
-    _price: u64,
-    _coupon_code: String,
-): u64 {
+public fun calculate_sale_price(_suins: &SuiNS, _price: u64, _coupon_code: String): u64 {
     abort 1337
 }
 

--- a/packages/coupons/sources/range.move
+++ b/packages/coupons/sources/range.move
@@ -9,7 +9,7 @@ module coupons::range;
 const EInvalidRange: u64 = 0;
 
 /// A Range for u8 helper
-public struct Range has copy, store, drop {
+public struct Range has copy, drop, store {
     vec: vector<u8>,
 }
 

--- a/packages/coupons/sources/rules.move
+++ b/packages/coupons/sources/rules.move
@@ -5,8 +5,7 @@
 // validation of names etc.
 module coupons::rules;
 
-use coupons::constants;
-use coupons::range::Range;
+use coupons::{constants, range::Range};
 use sui::clock::Clock;
 
 // Errors
@@ -31,7 +30,7 @@ const EInvalidAvailableClaims: u64 = 8;
 /// The Struct that holds the coupon's rules.
 /// All rules are combined in `AND` fashion.
 /// All of the checks have to pass for a coupon to be used.
-public struct CouponRules has copy, store, drop {
+public struct CouponRules has copy, drop, store {
     length: Option<Range>,
     available_claims: Option<u64>,
     user: Option<address>,
@@ -103,10 +102,7 @@ public fun has_available_claims(rules: &CouponRules): bool {
 }
 
 // Assertion helper for the validity of years.
-public fun assert_coupon_valid_for_domain_years(
-    rules: &CouponRules,
-    target: u8,
-) {
+public fun assert_coupon_valid_for_domain_years(rules: &CouponRules, target: u8) {
     assert!(is_coupon_valid_for_domain_years(rules, target), ENotValidYears);
 }
 
@@ -115,10 +111,7 @@ public fun assert_coupon_valid_for_domain_years(
 // That means we can create a combination of:
 // 1. Exact years (e.g. 2 years, by passing [2,2])
 // 2. Range of years (e.g. [1,3])
-public fun is_coupon_valid_for_domain_years(
-    rules: &CouponRules,
-    target: u8,
-): bool {
+public fun is_coupon_valid_for_domain_years(rules: &CouponRules, target: u8): bool {
     if (rules.years.is_none()) return true;
 
     rules.years.borrow().is_in_range(target)
@@ -137,21 +130,12 @@ public fun assert_is_valid_amount(_: u8, amount: u64) {
 
 // We check a DomainSize Rule against the length of a domain.
 // We return if the length is valid based on that.
-public fun assert_coupon_valid_for_domain_size(
-    rules: &CouponRules,
-    length: u8,
-) {
-    assert!(
-        is_coupon_valid_for_domain_size(rules, length),
-        EInvalidForDomainLength,
-    )
+public fun assert_coupon_valid_for_domain_size(rules: &CouponRules, length: u8) {
+    assert!(is_coupon_valid_for_domain_size(rules, length), EInvalidForDomainLength)
 }
 
 /// We check the length of the name based on the domain length rule
-public fun is_coupon_valid_for_domain_size(
-    rules: &CouponRules,
-    length: u8,
-): bool {
+public fun is_coupon_valid_for_domain_size(rules: &CouponRules, length: u8): bool {
     // If the vec is not set, we pass this rule test.
     if (rules.length.is_none()) return true;
 
@@ -165,10 +149,7 @@ public fun assert_coupon_valid_for_address(rules: &CouponRules, user: address) {
 }
 
 /// Check that the domain is valid for the specified address
-public fun is_coupon_valid_for_address(
-    rules: &CouponRules,
-    user: address,
-): bool {
+public fun is_coupon_valid_for_address(rules: &CouponRules, user: address): bool {
     if (rules.user.is_none()) return true;
     rules.user.borrow() == user
 }

--- a/packages/coupons/tests/authorization_tests.move
+++ b/packages/coupons/tests/authorization_tests.move
@@ -5,8 +5,10 @@
 #[test_only]
 module coupons::app_authorization_tests;
 
-use coupons::coupon_house::{Self, deauthorize_app};
-use coupons::setup::{Self, TestApp, admin, user, test_init};
+use coupons::{
+    coupon_house::{Self, deauthorize_app},
+    setup::{Self, TestApp, admin, user, test_init}
+};
 use sui::test_scenario::{return_shared, return_to_sender, end};
 use suins::suins::SuiNS;
 
@@ -47,12 +49,7 @@ fun authorized_app_get_app_success() {
     end(scenario_val);
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::coupons::coupon_house::EAppNotAuthorized,
-    ),
-]
+#[test, expected_failure(abort_code = ::coupons::coupon_house::EAppNotAuthorized)]
 fun unauthorized_app_failure() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;

--- a/packages/coupons/tests/coupons_tests.move
+++ b/packages/coupons/tests/coupons_tests.move
@@ -4,28 +4,17 @@
 #[test_only]
 module coupons::coupon_tests;
 
-use coupons::constants;
-use coupons::coupon_house;
-use coupons::data;
-use coupons::range;
-use coupons::rules;
-use coupons::setup::{
-    Self,
-    TestApp,
-    user,
-    user_two,
-    test_app,
-    admin_add_coupon,
-    test_init,
-    mist_per_sui
+use coupons::{
+    constants,
+    coupon_house,
+    data,
+    range,
+    rules,
+    setup::{Self, TestApp, user, user_two, test_app, admin_add_coupon, test_init, mist_per_sui}
 };
 use std::string::String;
-use sui::clock::Clock;
-use sui::test_scenario::{Scenario, return_shared};
-use sui::test_utils::{Self, destroy};
-use suins::payment::PaymentIntent;
-use suins::suins::SuiNS;
-use suins::suins_registration::SuinsRegistration;
+use sui::{clock::Clock, test_scenario::{Scenario, return_shared}, test_utils::{Self, destroy}};
+use suins::{payment::PaymentIntent, suins::SuiNS, suins_registration::SuinsRegistration};
 
 // populate a lot of coupons with different cases.
 // This populates the coupon as an authorized app
@@ -226,12 +215,7 @@ fun max_years_two_failure() {
 
 // Tests the e2e experience for coupons (a list of different coupons with
 // different rules)
-#[
-    test,
-    expected_failure(
-        abort_code = ::coupons::coupon_house::ECouponNotExists,
-    ),
-]
+#[test, expected_failure(abort_code = ::coupons::coupon_house::ECouponNotExists)]
 fun no_more_available_claims_failure() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
@@ -304,12 +288,7 @@ fun coupon_not_valid_for_years_failure() {
     scenario_val.end();
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::coupons::rules::EInvalidForDomainLength,
-    ),
-]
+#[test, expected_failure(abort_code = ::coupons::rules::EInvalidForDomainLength)]
 fun coupon_invalid_length_1_failure() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
@@ -325,12 +304,7 @@ fun coupon_invalid_length_1_failure() {
     scenario_val.end();
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::coupons::rules::EInvalidForDomainLength,
-    ),
-]
+#[test, expected_failure(abort_code = ::coupons::rules::EInvalidForDomainLength)]
 fun coupon_invalid_length_2_failure() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
@@ -346,12 +320,7 @@ fun coupon_invalid_length_2_failure() {
     scenario_val.end();
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::coupons::rules::EInvalidForDomainLength,
-    ),
-]
+#[test, expected_failure(abort_code = ::coupons::rules::EInvalidForDomainLength)]
 fun coupon_invalid_length_3_failure() {
     let mut scenario_val = test_init();
     let scenario = &mut scenario_val;
@@ -477,9 +446,7 @@ fun test_coupon_register(
             scenario.ctx(),
         );
         if (amount.is_some()) {
-            assert!(
-                intent.request_data().base_amount() == amount.get_with_default(0),
-            );
+            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
         };
 
         return_shared(suins);
@@ -520,9 +487,7 @@ fun test_coupon_renewal(
             scenario.ctx(),
         );
         if (amount.is_some()) {
-            assert!(
-                intent.request_data().base_amount() == amount.get_with_default(0),
-            );
+            assert!(intent.request_data().base_amount() == amount.get_with_default(0));
         };
 
         return_shared(suins);
@@ -538,11 +503,7 @@ fun init_registration(suins: &mut SuiNS, domain: String): PaymentIntent {
     intent
 }
 
-fun init_renewal(
-    suins: &mut SuiNS,
-    nft: &SuinsRegistration,
-    years: u8,
-): PaymentIntent {
+fun init_renewal(suins: &mut SuiNS, nft: &SuinsRegistration, years: u8): PaymentIntent {
     let intent = suins::payment::init_renewal(suins, nft, years);
 
     intent

--- a/packages/coupons/tests/setup.move
+++ b/packages/coupons/tests/setup.move
@@ -4,16 +4,10 @@
 #[test_only]
 module coupons::setup;
 
-use coupons::constants;
-use coupons::coupon_house::{Self, CouponsApp};
-use coupons::data::Data;
-use coupons::range;
-use coupons::rules;
+use coupons::{constants, coupon_house::{Self, CouponsApp}, data::Data, range, rules};
 use std::string::{utf8, String};
-use sui::clock;
-use sui::test_scenario::{Self, Scenario, ctx};
-use suins::registry;
-use suins::suins::{Self, AdminCap, SuiNS};
+use sui::{clock, test_scenario::{Self, Scenario, ctx}};
+use suins::{registry, suins::{Self, AdminCap, SuiNS}};
 
 public struct TestApp has drop {}
 
@@ -178,12 +172,7 @@ public fun populate_coupons(data_mut: &mut Data, ctx: &mut TxContext) {
 }
 
 // Adds a 0 rule coupon that gives 15% discount to test admin additions.
-public fun admin_add_coupon(
-    code_name: String,
-    kind: u8,
-    value: u64,
-    scenario: &mut Scenario,
-) {
+public fun admin_add_coupon(code_name: String, kind: u8, value: u64, scenario: &mut Scenario) {
     scenario.next_tx(admin());
     let mut suins = scenario.take_shared<SuiNS>();
     let cap = scenario.take_from_sender<AdminCap>();

--- a/packages/day_one/sources/day_one.move
+++ b/packages/day_one/sources/day_one.move
@@ -2,155 +2,142 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// This module defines the `DayOne` Object airdropped to early supporters of the SuiNS project.
-module day_one::day_one {
+module day_one::day_one;
 
-    use sui::{
-        package,
-        hash,
-        dynamic_field as df,
-        bcs,
-    };
+use sui::{bcs, dynamic_field as df, hash, package};
 
-    ///  We mark as friend just the BOGO module.
-    /// This is the only one that can activate a DayOne object.
-    /// This is a one-time operation that won't happen from any other modules.
+///  We mark as friend just the BOGO module.
+/// This is the only one that can activate a DayOne object.
+/// This is a one-time operation that won't happen from any other modules.
 
-    /// The shared object that stores the receivers destination.
-    public struct DropList has key {
-        id: UID,
-        total_minted: u32
-    }
+/// The shared object that stores the receivers destination.
+public struct DropList has key {
+    id: UID,
+    total_minted: u32,
+}
 
-    /// The Setup Capability for the airdrop module. Sent to the publisher on
-    /// publish. Consumed in the setup call.
-    public struct SetupCap has key { id: UID }
+/// The Setup Capability for the airdrop module. Sent to the publisher on
+/// publish. Consumed in the setup call.
+public struct SetupCap has key { id: UID }
 
-    /// == ERRORS ==
-    // Error emitted when trying to mint with invalid addresses (non existent DF).
-    const ENotFound: u64 = 0;
+/// == ERRORS ==
+// Error emitted when trying to mint with invalid addresses (non existent DF).
+const ENotFound: u64 = 0;
 
-    // Error emitted when passing more than 1000 hashes to the setup function.
-    const ETooManyHashes: u64 = 1;
+// Error emitted when passing more than 1000 hashes to the setup function.
+const ETooManyHashes: u64 = 1;
 
-    /// OTW for the Publisher object
-    public struct DAY_ONE has drop {}
+/// OTW for the Publisher object
+public struct DAY_ONE has drop {}
 
-    /// Share the `DropList` object, send the `SetupCap` to the publisher.
-    fun init(otw: DAY_ONE, ctx: &mut TxContext) {
-        // Claim the `Publisher` for the package!
-        package::claim_and_keep(otw, ctx);
+/// Share the `DropList` object, send the `SetupCap` to the publisher.
+fun init(otw: DAY_ONE, ctx: &mut TxContext) {
+    // Claim the `Publisher` for the package!
+    package::claim_and_keep(otw, ctx);
 
-        transfer::share_object(DropList { id: object::new(ctx), total_minted: 0 });
-        // For SuiNS, we need 1 SetupCap to manage all the required addresses. We'll be setting up around 75K addresses.
-        // We can mint 2K objects per run!
-        transfer::transfer(SetupCap { id: object::new(ctx) }, ctx.sender());
-    }
+    transfer::share_object(DropList { id: object::new(ctx), total_minted: 0 });
+    // For SuiNS, we need 1 SetupCap to manage all the required addresses. We'll be setting up around 75K addresses.
+    // We can mint 2K objects per run!
+    transfer::transfer(SetupCap { id: object::new(ctx) }, ctx.sender());
+}
 
-    /// The DayOne object, granting participants special offers in
-    /// different future promotions.
-    public struct DayOne has key, store {
-        id: UID,
-        active: bool,
-        serial: u32
-    }
+/// The DayOne object, granting participants special offers in
+/// different future promotions.
+public struct DayOne has key, store {
+    id: UID,
+    active: bool,
+    serial: u32,
+}
 
-    /// Mint the DayOne objects for the recipients. Can be triggered by anyone.
-    /// The only functionality it has is mint the DayOne & send it to the an address
-    /// that is part of the list.
-    public fun mint(
-        self: &mut DropList,
-        mut recipients: vector<address>,
-        ctx: &mut TxContext
-    ) {
+/// Mint the DayOne objects for the recipients. Can be triggered by anyone.
+/// The only functionality it has is mint the DayOne & send it to the an address
+/// that is part of the list.
+public fun mint(self: &mut DropList, mut recipients: vector<address>, ctx: &mut TxContext) {
+    let bytes = bcs::to_bytes(&recipients);
+    let hash = hash::blake2b256(&bytes);
 
-        let bytes = bcs::to_bytes(&recipients);
-        let hash = hash::blake2b256(&bytes);
+    // fails if not found.
+    let lookup = df::remove_if_exists(&mut self.id, sui::address::from_bytes(hash));
+    assert!(lookup.is_some<bool>(), ENotFound);
 
-        // fails if not found.
-        let lookup = df::remove_if_exists(&mut self.id, sui::address::from_bytes(hash));
-        assert!(lookup.is_some<bool>(), ENotFound);
+    let mut i: u32 = self.total_minted;
 
-        let mut i: u32 = self.total_minted;
-
-        while (vector::length(&recipients) > 0) {
-            let recipient = recipients.pop_back();
-            transfer::public_transfer(DayOne {
+    while (vector::length(&recipients) > 0) {
+        let recipient = recipients.pop_back();
+        transfer::public_transfer(
+            DayOne {
                 id: object::new(ctx),
                 active: false,
-                serial: i + 1
-            }, recipient);
-            i = i + 1;
-        };
+                serial: i + 1,
+            },
+            recipient,
+        );
+        i = i + 1;
+    };
 
-        // assign i to total_minted.
-        self.total_minted = i
+    // assign i to total_minted.
+    self.total_minted = i
+}
+
+/// Setup the airdrop module. This is called by the publisher.
+/// Hashes can be a vector of up to 1000 elements.
+/// Hashes needs to be generated by the `buffer` module.
+public fun setup(self: &mut DropList, cap: SetupCap, mut hashes: vector<address>) {
+    // verify we only pass less than 1000 hashes at the setup.
+    // That's the max amount of DFs we can create in a single run.
+    assert!(hashes.length() <= 1000, ETooManyHashes);
+
+    let SetupCap { id } = cap;
+    id.delete();
+
+    // attach every hash as a dynamic field to the `DropList` object;
+    while (hashes.length() > 0) {
+        df::add(&mut self.id, hashes.pop_back(), true);
+    };
+}
+
+/// Private helper to activate the DayOne object
+/// Will only be called by the `bogo` module (friend), which marks the
+/// beginning of the DayOne promotions.
+public(package) fun activate(self: &mut DayOne) {
+    self.active = true
+}
+
+// === Distribution ===
+
+/// Get the immutable reference to the UID of the DayOne object.
+public fun uid(self: &DayOne): &UID { &self.id }
+
+/// Get the mutable reference to the UID of the DayOne object.
+public fun uid_mut(self: &mut DayOne): &mut UID { &mut self.id }
+
+/// Get if a day_one object is active. Used for future promotions
+/// of the DayOne Object
+public fun is_active(self: &DayOne): bool {
+    self.active
+}
+
+#[test_only]
+public fun mint_for_testing(ctx: &mut TxContext): DayOne {
+    DayOne {
+        id: object::new(ctx),
+        active: false,
+        serial: 0,
     }
+}
 
-    /// Setup the airdrop module. This is called by the publisher.
-    /// Hashes can be a vector of up to 1000 elements.
-    /// Hashes needs to be generated by the `buffer` module.
-    public fun setup(
-        self: &mut DropList,
-        cap: SetupCap,
-        mut hashes: vector<address>,
-    ) {
-        // verify we only pass less than 1000 hashes at the setup.
-        // That's the max amount of DFs we can create in a single run.
-        assert!(hashes.length() <= 1000, ETooManyHashes);
+#[test_only]
+public fun burn_for_testing(nft: DayOne) {
+    let DayOne {
+        id,
+        active: _,
+        serial: _,
+    } = nft;
 
-        let SetupCap { id } = cap;
-        id.delete();
+    id.delete();
+}
 
-        // attach every hash as a dynamic field to the `DropList` object;
-        while (hashes.length() > 0) {
-            df::add(&mut self.id, hashes.pop_back(), true);
-        };
-    }
-
-    /// Private helper to activate the DayOne object
-    /// Will only be called by the `bogo` module (friend), which marks the
-    /// beginning of the DayOne promotions.
-    public(package) fun activate(self: &mut DayOne) {
-        self.active = true
-    }
-
-    // === Distribution ===
-
-    /// Get the immutable reference to the UID of the DayOne object.
-    public fun uid(self: &DayOne): &UID { &self.id }
-
-    /// Get the mutable reference to the UID of the DayOne object.
-    public fun uid_mut(self: &mut DayOne): &mut UID { &mut self.id }
-
-    /// Get if a day_one object is active. Used for future promotions
-    /// of the DayOne Object
-    public fun is_active(self: &DayOne): bool {
-        self.active
-    }
-
-
-    #[test_only]
-    public fun mint_for_testing(ctx: &mut TxContext): DayOne {
-        DayOne {
-            id: object::new(ctx),
-            active: false,
-            serial: 0,
-        }
-    }
-
-    #[test_only]
-    public fun burn_for_testing(nft: DayOne) {
-        let DayOne {
-            id,
-            active: _,
-            serial: _
-        } = nft;
-
-        id.delete();
-    }
-
-    #[test_only]
-    public fun set_is_active_for_testing(nft: &mut DayOne, status: bool) {
-        nft.active = status;
-    }
+#[test_only]
+public fun set_is_active_for_testing(nft: &mut DayOne, status: bool) {
+    nft.active = status;
 }

--- a/packages/day_one/tests/day_one_tests.move
+++ b/packages/day_one/tests/day_one_tests.move
@@ -1,310 +1,393 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test_only]
-module suins::day_one_tests {
-    use std::string::{utf8, String};
-    use sui::{
-        clock::{Self, Clock},
-        test_scenario::{Self, Scenario, ctx},
+module suins::day_one_tests;
+
+use day_one::{bogo::{Self, BogoApp}, day_one::{Self, DayOne}};
+use std::string::{utf8, String};
+use sui::{clock::{Self, Clock}, test_scenario::{Self, Scenario, ctx}};
+use suins::{
+    domain,
+    registry,
+    suins::{Self, SuiNS, AdminCap},
+    suins_registration::{Self as nft, SuinsRegistration}
+};
+
+const SUINS_ADDRESS: address = @0xA001;
+const USER_ADDRESS: address = @0xA002;
+
+fun test_init(): Scenario {
+    let mut scenario_val = test_scenario::begin(SUINS_ADDRESS);
+    let scenario = &mut scenario_val;
+    {
+        let mut suins = suins::init_for_testing(ctx(scenario));
+        suins.authorize_app_for_testing<BogoApp>();
+        suins.share_for_testing();
+        let clock = clock::create_for_testing(ctx(scenario));
+        clock.share_for_testing();
     };
+    {
+        scenario.next_tx(SUINS_ADDRESS);
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+        let mut suins = scenario.take_shared<SuiNS>();
 
-    use suins::{
-        suins_registration::{Self as nft, SuinsRegistration},
-        domain,
-        registry,
-        suins::{Self, SuiNS, AdminCap},
+        registry::init_for_testing(&admin_cap, &mut suins, ctx(scenario));
+
+        test_scenario::return_shared(suins);
+        scenario.return_to_sender(admin_cap);
     };
+    scenario_val
+}
 
-    use day_one::{
-        day_one::{Self, DayOne},
-        bogo::{Self, BogoApp},
-    };
+#[test]
+fun test_e2e() {
+    // an e2e scenario were we just purchase 3 domains normally using 3 registered ones.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (mut domain1, mut domain2, mut domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-    const SUINS_ADDRESS: address = @0xA001;
-    const USER_ADDRESS: address =  @0xA002;
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain1,
+        utf8(b"wow.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    let new_name_2 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain2,
+        utf8(b"wow1.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    let new_name_3 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain3,
+        utf8(b"wow11.sui"),
+        &clock,
+        ctx(scenario),
+    );
 
-    fun test_init(): Scenario {
-        let mut scenario_val = test_scenario::begin(SUINS_ADDRESS);
-        let scenario = &mut scenario_val;
-        {
-            let mut suins = suins::init_for_testing(ctx(scenario));
-            suins.authorize_app_for_testing<BogoApp>();
-            suins.share_for_testing();
-            let clock = clock::create_for_testing(ctx(scenario));
-            clock.share_for_testing();
-        };
-        {
-            scenario.next_tx(SUINS_ADDRESS);
-            let admin_cap = scenario.take_from_sender<AdminCap>();
-            let mut suins = scenario.take_shared<SuiNS>();
+    // we can verify that day one got activated here.
+    assert!(day_one::is_active(&day_one), 0);
 
-            registry::init_for_testing(&admin_cap, &mut suins, ctx(scenario));
+    burn_domain(new_name_1);
+    burn_domain(new_name_2);
+    burn_domain(new_name_3);
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-            test_scenario::return_shared(suins);
-            scenario.return_to_sender(admin_cap);
-        };
-        scenario_val
-    }
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-    #[test]
-    fun test_e2e() {
-        // an e2e scenario were we just purchase 3 domains normally using 3 registered ones.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (mut domain1, mut domain2, mut domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+#[test]
+#[expected_failure(abort_code = bogo::EDomainAlreadyUsed)]
+fun failure_test_domain_already_used() {
+    // tries to reuse the same SuinsRegistration for a second time.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain1, utf8(b"wow.sui"), &clock, ctx(scenario));
-        let new_name_2 = bogo::claim(&mut day_one, &mut suins, &mut domain2, utf8(b"wow1.sui"), &clock, ctx(scenario));
-        let new_name_3 = bogo::claim(&mut day_one, &mut suins, &mut domain3, utf8(b"wow11.sui"), &clock, ctx(scenario));
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain1,
+        utf8(b"wow.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    let new_name_2 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain1,
+        utf8(b"wop.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    burn_domain(new_name_1);
+    burn_domain(new_name_2);
 
-        // we can verify that day one got activated here.
-        assert!(day_one::is_active(&day_one), 0);
+    cleanup(domain1, domain2, domain3, day_one);
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-        burn_domain(new_name_1);
-        burn_domain(new_name_2);
-        burn_domain(new_name_3);
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+#[test]
+#[expected_failure(abort_code = bogo::EDomainAlreadyUsed)]
+fun failure_test_free_minted_domain_use() {
+    // an e2e scenario were we just purchase 3 domains normally using 3 registered ones.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+    let mut new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain1,
+        utf8(b"wow.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    let new_name_2 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut new_name_1,
+        utf8(b"wop.sui"),
+        &clock,
+        ctx(scenario),
+    );
 
+    burn_domain(new_name_1);
+    burn_domain(new_name_2);
 
-    #[test]
-    #[expected_failure(abort_code = bogo::EDomainAlreadyUsed)]
-    fun failure_test_domain_already_used() {
-        // tries to reuse the same SuinsRegistration for a second time.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain1, utf8(b"wow.sui"), &clock, ctx(scenario));
-        let new_name_2 = bogo::claim(&mut day_one, &mut suins, &mut domain1, utf8(b"wop.sui"), &clock, ctx(scenario));
-        burn_domain(new_name_1);
-        burn_domain(new_name_2);
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-        cleanup(domain1, domain2, domain3, day_one);
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+#[test]
+#[expected_failure(abort_code = bogo::ESizeMissMatch)]
+fun failure_test_length_missmatch() {
+    // Tries to register a 4 letter domain while presenting a 3 letter one.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-    #[test]
-    #[expected_failure(abort_code = bogo::EDomainAlreadyUsed)]
-    fun failure_test_free_minted_domain_use() {
-      // an e2e scenario were we just purchase 3 domains normally using 3 registered ones.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain1,
+        utf8(b"wow1.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    burn_domain(new_name_1);
 
-        let mut new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain1, utf8(b"wow.sui"), &clock, ctx(scenario));
-        let new_name_2 = bogo::claim(&mut day_one, &mut suins, &mut new_name_1, utf8(b"wop.sui"), &clock, ctx(scenario));
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-        burn_domain(new_name_1);
-        burn_domain(new_name_2);
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+#[test]
+#[expected_failure(abort_code = bogo::ENotPurchasedInAuction)]
+fun failure_test_domain_not_bought_in_auction() {
+    // tries to use a fresh domain to get another one for free.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let mut clock = scenario.take_shared<Clock>();
+    let (domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+    // increment the clock by a lot.
+    clock::increment_for_testing(&mut clock, bogo::last_valid_expiration());
 
-    #[test]
-    #[expected_failure(abort_code = bogo::ESizeMissMatch)]
-    fun failure_test_length_missmatch() {
-      // Tries to register a 4 letter domain while presenting a 3 letter one.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+    let mut fresh_domain = new_domain(utf8(b"exp.sui"), 1, &clock, ctx(scenario));
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut fresh_domain,
+        utf8(b"wow.sui"),
+        &clock,
+        ctx(scenario),
+    );
 
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain1, utf8(b"wow1.sui"), &clock, ctx(scenario));
-        burn_domain(new_name_1);
+    burn_domain(new_name_1);
+    burn_domain(fresh_domain);
 
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-    #[test]
-    #[expected_failure(abort_code = bogo::ENotPurchasedInAuction)]
-    fun failure_test_domain_not_bought_in_auction() {
-        // tries to use a fresh domain to get another one for free.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let mut clock = scenario.take_shared<Clock>();
-        let (domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+#[test]
+#[expected_failure(abort_code = bogo::ESizeMissMatch)]
+fun failure_test_length_missmatch_2() {
+    // Tries to claim a 3 letter name using a 4 letter domain.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (domain1, mut domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-        // increment the clock by a lot.
-        clock::increment_for_testing(&mut clock, bogo::last_valid_expiration());
+    // using a 4 digit domain and trying to get a 3 digit one.
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain2,
+        utf8(b"wow.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    burn_domain(new_name_1);
 
-        let mut fresh_domain = new_domain(utf8(b"exp.sui"), 1, &clock, ctx(scenario));
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut fresh_domain, utf8(b"wow.sui"), &clock, ctx(scenario));
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-        burn_domain(new_name_1);
-        burn_domain(fresh_domain);
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+#[test]
+#[expected_failure(abort_code = bogo::ESizeMissMatch)]
+fun failure_test_length_missmatch_3() {
+    // tries to get a 4 digit name using a 5 digit one.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (domain1, domain2, mut domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain3,
+        utf8(b"woww.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    burn_domain(new_name_1);
 
-    #[test]
-    #[expected_failure(abort_code = bogo::ESizeMissMatch)]
-    fun failure_test_length_missmatch_2() {
-        // Tries to claim a 3 letter name using a 4 letter domain.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (domain1, mut domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-        // using a 4 digit domain and trying to get a 3 digit one.
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain2, utf8(b"wow.sui"), &clock, ctx(scenario));
-        burn_domain(new_name_1);
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+#[test]
+#[expected_failure(abort_code = bogo::ESizeMissMatch)]
+fun failure_test_length_missmatch_4() {
+    // tries to get an 8 digit name using a 3 digit one.
+    // protects the user from mistakes.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain1,
+        utf8(b"wowowowo.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    burn_domain(new_name_1);
 
-    #[test]
-    #[expected_failure(abort_code = bogo::ESizeMissMatch)]
-    fun failure_test_length_missmatch_3() {
-        // tries to get a 4 digit name using a 5 digit one.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (domain1, domain2, mut domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain3, utf8(b"woww.sui"), &clock, ctx(scenario));
-        burn_domain(new_name_1);
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+#[test]
+fun test_acceptable_length_missmatch() {
+    // We allow purchasing a domain of size 5+ if we pass a 5 length domain.
+    // we only care about 3 & 4 digits.
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    scenario.next_tx(USER_ADDRESS);
+    let clock = scenario.take_shared<Clock>();
+    let (domain1, domain2, mut domain3, mut day_one) = prepare(ctx(scenario), &clock);
+    let mut suins = scenario.take_shared<SuiNS>();
+    let new_name_1 = bogo::claim(
+        &mut day_one,
+        &mut suins,
+        &mut domain3,
+        utf8(b"wowwowowo.sui"),
+        &clock,
+        ctx(scenario),
+    );
+    burn_domain(new_name_1);
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+    // clean up all these domains.
+    cleanup(domain1, domain2, domain3, day_one);
 
-    #[test]
-    #[expected_failure(abort_code = bogo::ESizeMissMatch)]
-    fun failure_test_length_missmatch_4() {
-        // tries to get an 8 digit name using a 3 digit one.
-        // protects the user from mistakes.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (mut domain1, domain2, domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
+    test_scenario::return_shared(suins);
+    test_scenario::return_shared(clock);
+    scenario_val.end();
+}
 
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain1, utf8(b"wowowowo.sui"), &clock, ctx(scenario));
-        burn_domain(new_name_1);
+// === Helpers ===
 
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+// destroys all the created objects
+fun cleanup(
+    domain1: SuinsRegistration,
+    domain2: SuinsRegistration,
+    domain3: SuinsRegistration,
+    day_one: DayOne,
+) {
+    day_one::burn_for_testing(day_one);
+    burn_domain(domain1);
+    burn_domain(domain2);
+    burn_domain(domain3);
+}
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+// Helper function. Registers 3 domains and returns 2 day_ones to play with;
+fun prepare(
+    ctx: &mut TxContext,
+    clock: &Clock,
+): (SuinsRegistration, SuinsRegistration, SuinsRegistration, DayOne) {
+    let domain1 = new_domain(utf8(b"tes.sui"), 1, clock, ctx);
+    let domain2 = new_domain(utf8(b"test.sui"), 1, clock, ctx);
+    let domain3 = new_domain(utf8(b"test1.sui"), 1, clock, ctx);
 
-    #[test]
-    fun test_acceptable_length_missmatch() {
-        // We allow purchasing a domain of size 5+ if we pass a 5 length domain.
-        // we only care about 3 & 4 digits.
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        scenario.next_tx(USER_ADDRESS);
-        let clock = scenario.take_shared<Clock>();
-        let (domain1, domain2, mut domain3, mut day_one) = prepare(ctx(scenario), &clock);
-        let mut suins = scenario.take_shared<SuiNS>();
-        let new_name_1 = bogo::claim(&mut day_one, &mut suins, &mut domain3, utf8(b"wowwowowo.sui"), &clock, ctx(scenario));
-        burn_domain(new_name_1);
+    let day_one = day_one::mint_for_testing(ctx);
 
-        // clean up all these domains.
-        cleanup(domain1, domain2, domain3, day_one);
+    (domain1, domain2, domain3, day_one)
+}
 
-        test_scenario::return_shared(suins);
-        test_scenario::return_shared(clock);
-        scenario_val.end();
-    }
+fun new_domain(
+    domain_name: String,
+    no_years: u8,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): SuinsRegistration {
+    nft::new_for_testing(
+        domain::new(domain_name),
+        no_years,
+        clock,
+        ctx,
+    )
+}
 
-
-    // === Helpers ===
-
-    // destroys all the created objects
-    fun cleanup(
-        domain1: SuinsRegistration,
-        domain2: SuinsRegistration,
-        domain3: SuinsRegistration,
-        day_one: DayOne
-    ){
-        day_one::burn_for_testing(day_one);
-        burn_domain(domain1);
-        burn_domain(domain2);
-        burn_domain(domain3);
-    }
-
-    // Helper function. Registers 3 domains and returns 2 day_ones to play with;
-    fun prepare(ctx: &mut TxContext, clock: &Clock):
-        (SuinsRegistration, SuinsRegistration, SuinsRegistration, DayOne){
-
-        let domain1 = new_domain(utf8(b"tes.sui"), 1, clock, ctx);
-        let domain2 = new_domain(utf8(b"test.sui"), 1, clock, ctx);
-        let domain3 = new_domain(utf8(b"test1.sui"), 1, clock, ctx);
-
-        let day_one = day_one::mint_for_testing(ctx);
-
-        (domain1, domain2, domain3, day_one)
-
-    }
-
-    fun new_domain(
-        domain_name: String,
-        no_years: u8,
-        clock: &Clock,
-        ctx: &mut TxContext,
-    ): SuinsRegistration {
-        nft::new_for_testing(
-            domain::new(domain_name),
-            no_years,
-            clock,
-            ctx,
-        )
-    }
-
-    fun burn_domain(nft: SuinsRegistration) {
-        nft.burn_for_testing()
-    }
-
+fun burn_domain(nft: SuinsRegistration) {
+    nft.burn_for_testing()
 }

--- a/packages/denylist/sources/denylist.move
+++ b/packages/denylist/sources/denylist.move
@@ -1,107 +1,109 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module denylist::denylist {
-    use std::string::String;
+module denylist::denylist;
 
-    use sui::table::{Self, Table};
-    
-    use suins::suins::{Self, AdminCap, SuiNS};
+use std::string::String;
+use sui::table::{Self, Table};
+use suins::suins::{Self, AdminCap, SuiNS};
 
-    /// No names in the passed list
-    const ENoWordsInList: u64 = 1;
+/// No names in the passed list
+const ENoWordsInList: u64 = 1;
 
-    /// A wrapper that holds the reserved and blocked names.
-    public struct Denylist has store {
-        // The list of reserved names. 
-        // Our public SLD registrations will be checking against it.
-        reserved: Table<String, bool>,
-        // The list of blocked names.
-        // Subdomains + registrations will be checking against.
-        blocked: Table<String, bool>,
-    }
+/// A wrapper that holds the reserved and blocked names.
+public struct Denylist has store {
+    // The list of reserved names.
+    // Our public SLD registrations will be checking against it.
+    reserved: Table<String, bool>,
+    // The list of blocked names.
+    // Subdomains + registrations will be checking against.
+    blocked: Table<String, bool>,
+}
 
-    /// The authorization for the denylist registry.
-    public struct DenyListAuth has drop {}
+/// The authorization for the denylist registry.
+public struct DenyListAuth has drop {}
 
-    public fun setup(suins: &mut SuiNS, cap: &AdminCap, ctx: &mut TxContext) {
-        suins::add_registry(cap, suins, Denylist {
-            reserved: table::new(ctx),
-            blocked: table::new(ctx)
-        });
-    }
-
-    /// Check for a reserved name
-    public fun is_reserved_name(suins: &SuiNS, name: String): bool {
-        denylist(suins).reserved.contains(name)
-    }
-
-    /// Checks for a blocked name.
-    public fun is_blocked_name(suins: &SuiNS, name: String): bool {
-        denylist(suins).blocked.contains(name)
-    }
-
-    /// Add a list of reserved names to the list as admin.
-    public fun add_reserved_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
-        internal_add_names_to_list(&mut denylist_mut(suins).reserved, words);
-    }
-
-    /// Add a list of offensive names to the list as admin.
-    public fun add_blocked_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
-        internal_add_names_to_list(&mut denylist_mut(suins).blocked, words);
-    }
-
-    /// Remove a list of words from the reserved names list.
-    public fun remove_reserved_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
-        internal_remove_names_from_list(&mut denylist_mut(suins).reserved, words);
-    }
-
-    /// Remove a list of words from the list as admin.
-    public fun remove_blocked_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
-        internal_remove_names_from_list(&mut denylist_mut(suins).blocked, words);
-    }
-
-    /// Get immutable access to the registry.
-    fun denylist(suins: &SuiNS): &Denylist {
-        suins.registry()
-    }
-
-    /// Internal helper to get access to the BlockedNames object
-    fun denylist_mut(suins: &mut SuiNS): &mut Denylist {
-        suins::app_registry_mut<DenyListAuth, Denylist>(DenyListAuth {}, suins)
-    }
-
-    /// Internal helper to batch add words to a table.
-    fun internal_add_names_to_list(table: &mut Table<String, bool>, words: vector<String>) {
-        assert!(words.length() > 0, ENoWordsInList);
-
-        let mut i = words.length();
-
-        while (i > 0) {
-            i = i - 1;
-            let word = words[i];
-            table.add(word, true);
-        };
-    }
-
-    /// Internal helper to remove words from a table.
-    fun internal_remove_names_from_list(table: &mut Table<String, bool>, words: vector<String>) {
-        assert!(words.length() > 0, ENoWordsInList);
-
-        let mut i = words.length();
-
-        while (i > 0) {
-            i = i - 1;
-            let word = words[i];
-            table.remove(word);
-        };
-    }
-
-    #[test_only]
-    public fun new_for_testing(ctx: &mut TxContext): Denylist {
+public fun setup(suins: &mut SuiNS, cap: &AdminCap, ctx: &mut TxContext) {
+    suins::add_registry(
+        cap,
+        suins,
         Denylist {
             reserved: table::new(ctx),
-            blocked: table::new(ctx)
-        }
+            blocked: table::new(ctx),
+        },
+    );
+}
+
+/// Check for a reserved name
+public fun is_reserved_name(suins: &SuiNS, name: String): bool {
+    denylist(suins).reserved.contains(name)
+}
+
+/// Checks for a blocked name.
+public fun is_blocked_name(suins: &SuiNS, name: String): bool {
+    denylist(suins).blocked.contains(name)
+}
+
+/// Add a list of reserved names to the list as admin.
+public fun add_reserved_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+    internal_add_names_to_list(&mut denylist_mut(suins).reserved, words);
+}
+
+/// Add a list of offensive names to the list as admin.
+public fun add_blocked_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+    internal_add_names_to_list(&mut denylist_mut(suins).blocked, words);
+}
+
+/// Remove a list of words from the reserved names list.
+public fun remove_reserved_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+    internal_remove_names_from_list(&mut denylist_mut(suins).reserved, words);
+}
+
+/// Remove a list of words from the list as admin.
+public fun remove_blocked_names(suins: &mut SuiNS, _: &AdminCap, words: vector<String>) {
+    internal_remove_names_from_list(&mut denylist_mut(suins).blocked, words);
+}
+
+/// Get immutable access to the registry.
+fun denylist(suins: &SuiNS): &Denylist {
+    suins.registry()
+}
+
+/// Internal helper to get access to the BlockedNames object
+fun denylist_mut(suins: &mut SuiNS): &mut Denylist {
+    suins::app_registry_mut<DenyListAuth, Denylist>(DenyListAuth {}, suins)
+}
+
+/// Internal helper to batch add words to a table.
+fun internal_add_names_to_list(table: &mut Table<String, bool>, words: vector<String>) {
+    assert!(words.length() > 0, ENoWordsInList);
+
+    let mut i = words.length();
+
+    while (i > 0) {
+        i = i - 1;
+        let word = words[i];
+        table.add(word, true);
+    };
+}
+
+/// Internal helper to remove words from a table.
+fun internal_remove_names_from_list(table: &mut Table<String, bool>, words: vector<String>) {
+    assert!(words.length() > 0, ENoWordsInList);
+
+    let mut i = words.length();
+
+    while (i > 0) {
+        i = i - 1;
+        let word = words[i];
+        table.remove(word);
+    };
+}
+
+#[test_only]
+public fun new_for_testing(ctx: &mut TxContext): Denylist {
+    Denylist {
+        reserved: table::new(ctx),
+        blocked: table::new(ctx),
     }
 }

--- a/packages/denylist/tests/denylist_tests.move
+++ b/packages/denylist/tests/denylist_tests.move
@@ -1,157 +1,153 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module denylist::denylist_tests {
-    use std::string::{utf8, String};
+module denylist::denylist_tests;
 
-    use sui::test_scenario::{Self as ts, Scenario};
+use denylist::denylist::{Self, DenyListAuth};
+use std::string::{utf8, String};
+use sui::test_scenario::{Self as ts, Scenario};
+use suins::suins::{Self, SuiNS};
 
-    use suins::suins::{Self, SuiNS};
+const ADDR: address = @0x0;
 
-    use denylist::denylist::{Self, DenyListAuth};
+#[test]
+fun test() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
 
-    const ADDR: address = @0x0;
+    scenario.next_tx(ADDR);
+    let mut suins = scenario.take_shared<SuiNS>();
+    let cap = suins::create_admin_cap_for_testing(scenario.ctx());
 
-    #[test]
-    fun test() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
+    denylist::add_reserved_names(&mut suins, &cap, some_reserved_names());
+    denylist::add_blocked_names(&mut suins, &cap, some_offensive_names());
 
+    assert!(denylist::is_reserved_name(&suins, utf8(b"test")), 0);
+    assert!(denylist::is_reserved_name(&suins, utf8(b"test2")), 0);
+
+    assert!(denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
+
+    assert!(!denylist::is_blocked_name(&suins, utf8(b"example")), 0);
+
+    assert!(!denylist::is_reserved_name(&suins, utf8(b"example")), 0);
+
+    suins::burn_admin_cap_for_testing(cap);
+
+    ts::return_shared(suins);
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::denylist::denylist::ENoWordsInList)]
+fun test_empty_addition_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+
+    scenario.next_tx(ADDR);
+    let mut suins = scenario.take_shared<SuiNS>();
+    let cap = suins::create_admin_cap_for_testing(scenario.ctx());
+
+    denylist::add_reserved_names(&mut suins, &cap, vector[]);
+
+    abort 1337
+}
+
+// coverage.. :)
+#[test, expected_failure(abort_code = ::denylist::denylist::ENoWordsInList)]
+fun test_empty_addition_blocked_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+
+    scenario.next_tx(ADDR);
+    let mut suins = scenario.take_shared<SuiNS>();
+    let cap = suins::create_admin_cap_for_testing(scenario.ctx());
+
+    denylist::add_blocked_names(&mut suins, &cap, vector[]);
+
+    abort 1337
+}
+
+#[test]
+fun remove_blocked_word() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+
+    scenario.next_tx(ADDR);
+    let mut suins = scenario.take_shared<SuiNS>();
+    let cap = suins::create_admin_cap_for_testing(scenario.ctx());
+
+    denylist::add_blocked_names(&mut suins, &cap, some_offensive_names());
+
+    assert!(denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
+
+    denylist::remove_blocked_names(&mut suins, &cap, vector[utf8(b"bad_test")]);
+
+    assert!(!denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
+
+    suins::burn_admin_cap_for_testing(cap);
+
+    ts::return_shared(suins);
+    scenario_val.end();
+}
+
+#[test]
+fun remove_reserved_word() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+
+    scenario.next_tx(ADDR);
+    let mut suins = scenario.take_shared<SuiNS>();
+    let cap = suins::create_admin_cap_for_testing(scenario.ctx());
+
+    denylist::add_reserved_names(&mut suins, &cap, some_reserved_names());
+
+    let name = utf8(b"test");
+
+    assert!(denylist::is_reserved_name(&suins, name), 0);
+
+    denylist::remove_reserved_names(&mut suins, &cap, vector[name]);
+
+    assert!(!denylist::is_reserved_name(&suins, name), 0);
+
+    suins::burn_admin_cap_for_testing(cap);
+
+    ts::return_shared(suins);
+    scenario_val.end();
+}
+
+// data preparation
+
+public fun test_init(): (Scenario) {
+    let mut scenario = ts::begin(ADDR);
+    {
         scenario.next_tx(ADDR);
-        let mut suins = scenario.take_shared<SuiNS>();
-        let cap = suins::create_admin_cap_for_testing(scenario.ctx());
 
-        denylist::add_reserved_names(&mut suins, &cap, some_reserved_names());
-        denylist::add_blocked_names(&mut suins, &cap, some_offensive_names());
+        let (mut suins, cap) = suins::new_for_testing(scenario.ctx());
 
+        suins.authorize_app_for_testing<DenyListAuth>();
 
-        assert!(denylist::is_reserved_name(&suins, utf8(b"test")), 0);
-        assert!(denylist::is_reserved_name(&suins, utf8(b"test2")), 0);
-    
-        assert!(denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
+        denylist::setup(&mut suins, &cap, scenario.ctx());
 
-        assert!(!denylist::is_blocked_name(&suins, utf8(b"example")), 0);
-
-        assert!(!denylist::is_reserved_name(&suins, utf8(b"example")), 0);
+        suins.share_for_testing();
 
         suins::burn_admin_cap_for_testing(cap);
+    };
 
-        ts::return_shared(suins);
-        scenario_val.end();
-    }
+    scenario
+}
 
-    #[test, expected_failure(abort_code = ::denylist::denylist::ENoWordsInList)]
-    fun test_empty_addition_failure(){
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
+fun some_reserved_names(): vector<String> {
+    let mut vec: vector<String> = vector::empty();
 
-        scenario.next_tx(ADDR);
-        let mut suins = scenario.take_shared<SuiNS>();
-        let cap = suins::create_admin_cap_for_testing(scenario.ctx());
+    vec.push_back(utf8(b"test"));
+    vec.push_back(utf8(b"test2"));
+    vec.push_back(utf8(b"test3"));
+    vec
+}
 
-        denylist::add_reserved_names(&mut suins, &cap, vector[]);
-
-        abort 1337
-    }
-
-    // coverage.. :) 
-    #[test, expected_failure(abort_code = ::denylist::denylist::ENoWordsInList)]
-    fun test_empty_addition_blocked_failure(){
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-
-        scenario.next_tx(ADDR);
-        let mut suins = scenario.take_shared<SuiNS>();
-        let cap = suins::create_admin_cap_for_testing(scenario.ctx());
-
-        denylist::add_blocked_names(&mut suins, &cap, vector[]);
-
-        abort 1337
-    }
-
-    #[test]
-    fun remove_blocked_word(){
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-
-        scenario.next_tx(ADDR);
-        let mut suins = scenario.take_shared<SuiNS>();
-        let cap = suins::create_admin_cap_for_testing(scenario.ctx());
-
-        denylist::add_blocked_names(&mut suins, &cap, some_offensive_names());
-
-        assert!(denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
-
-        denylist::remove_blocked_names(&mut suins, &cap, vector[utf8(b"bad_test")]);
-
-        assert!(!denylist::is_blocked_name(&suins, utf8(b"bad_test")), 0);
-
-        suins::burn_admin_cap_for_testing(cap);
-
-        ts::return_shared(suins);
-        scenario_val.end();
-    }
-
-    #[test]
-    fun remove_reserved_word(){
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-
-        scenario.next_tx(ADDR);
-        let mut suins = scenario.take_shared<SuiNS>();
-        let cap = suins::create_admin_cap_for_testing(scenario.ctx());
-
-        denylist::add_reserved_names(&mut suins, &cap, some_reserved_names());
-
-        let name = utf8(b"test");
-
-        assert!(denylist::is_reserved_name(&suins, name), 0);
-
-        denylist::remove_reserved_names(&mut suins, &cap, vector[name]);
-
-        assert!(!denylist::is_reserved_name(&suins, name), 0);
-
-        suins::burn_admin_cap_for_testing(cap);
-
-        ts::return_shared(suins);
-        scenario_val.end();
-    }
-
-    // data preparation
-
-    public fun test_init(): (Scenario) {
-        let mut scenario = ts::begin(ADDR);
-        {
-            scenario.next_tx(ADDR);
-
-            let (mut suins, cap) = suins::new_for_testing(scenario.ctx());
-
-            suins.authorize_app_for_testing<DenyListAuth>();
-
-            denylist::setup(&mut suins, &cap, scenario.ctx());
-
-            suins.share_for_testing();
-        
-            suins::burn_admin_cap_for_testing(cap);
-        };
-
-        scenario
-    }
-
-    fun some_reserved_names(): vector<String> {
-        let mut vec: vector<String> = vector::empty();
-
-        vec.push_back(utf8(b"test"));
-        vec.push_back(utf8(b"test2"));
-        vec.push_back(utf8(b"test3"));
-        vec
-    }
-
-    fun some_offensive_names(): vector<String> {
-        let mut vec: vector<String> = vector::empty();
-        vec.push_back(utf8(b"bad_test"));
-        vec.push_back(utf8(b"bad_test2"));
-        vec.push_back(utf8(b"bad_test3"));
-        vec
-    }
+fun some_offensive_names(): vector<String> {
+    let mut vec: vector<String> = vector::empty();
+    vec.push_back(utf8(b"bad_test"));
+    vec.push_back(utf8(b"bad_test2"));
+    vec.push_back(utf8(b"bad_test3"));
+    vec
 }

--- a/packages/discord/sources/discord.move
+++ b/packages/discord/sources/discord.move
@@ -19,270 +19,303 @@
 /// The moment the coupon is generated, the address can't change.
 
 /// The coupon's format that is being generated is calculated based on hash(discord_id + claim_idx)
-module discord::discord {
-    use std::string::String;
-    use sui:: {
-        vec_map::{Self, VecMap},
-        vec_set::{Self, VecSet},
-        bcs,
-        table::{Self, Table},
-        ecdsa_k1,
-        address,
-        hash,
-    };
-    use coupons::{
-        coupon_house,
-        rules,
-        range,
-        constants::{percentage_discount_type},
-    };
-    use suins::suins::SuiNS;
+module discord::discord;
 
-    /// Errors
+use coupons::{constants::percentage_discount_type, coupon_house, range, rules};
+use std::string::String;
+use sui::{
+    address,
+    bcs,
+    ecdsa_k1,
+    hash,
+    table::{Self, Table},
+    vec_map::{Self, VecMap},
+    vec_set::{Self, VecSet}
+};
+use suins::suins::SuiNS;
 
-    /// Public Key is not valid (empty array)
-    const EInvalidPublicKey: u64 = 0;
-    /// Discount not in range [0,100]
-    const EInvalidDiscount: u64 = 1;
-    /// Member already has that role attached
-    const ERoleAlreadyExists: u64 = 2;
-    /// Discord ID not found, even though mapping exists.
-    const EDiscordIdNotFound: u64 = 3;
-    /// Tries to attach empty vector of roles.
-    const ENoRolesFound: u64 = 4;
-    /// Tries to attach a non existing role to a member
-    const ERoleNotExists: u64 = 5;
-    /// Tries to attach a role which the member has already claimed the rewards for.
-    const ERoleAlreadyAssigned: u64 = 6;
-    /// Not a matching signature, can't do any attaching
-    const ESignatureNotMatch: u64 = 7;
-    /// Tries to claim a coupon without being in the system
-    const EAddressNoMapping: u64 = 8;
-    /// Tries to claim a coupon higher than the available points.
-    const ENotEnoughPoints: u64 = 9;
-    /// Tries to add an action without a public key on the contract
-    const ENoSignatureSet: u64 = 10;
+/// Errors
 
-    /// authorization struct, to allow the app to create coupons in the coupon system.
-    public struct DiscordApp has drop {}
+/// Public Key is not valid (empty array)
+const EInvalidPublicKey: u64 = 0;
+/// Discount not in range [0,100]
+const EInvalidDiscount: u64 = 1;
+/// Member already has that role attached
+const ERoleAlreadyExists: u64 = 2;
+/// Discord ID not found, even though mapping exists.
+const EDiscordIdNotFound: u64 = 3;
+/// Tries to attach empty vector of roles.
+const ENoRolesFound: u64 = 4;
+/// Tries to attach a non existing role to a member
+const ERoleNotExists: u64 = 5;
+/// Tries to attach a role which the member has already claimed the rewards for.
+const ERoleAlreadyAssigned: u64 = 6;
+/// Not a matching signature, can't do any attaching
+const ESignatureNotMatch: u64 = 7;
+/// Tries to claim a coupon without being in the system
+const EAddressNoMapping: u64 = 8;
+/// Tries to claim a coupon higher than the available points.
+const ENotEnoughPoints: u64 = 9;
+/// Tries to add an action without a public key on the contract
+const ENoSignatureSet: u64 = 10;
 
-    /// Capability for Discord Application.
-    public struct DiscordCap has key, store { id: UID }
+/// authorization struct, to allow the app to create coupons in the coupon system.
+public struct DiscordApp has drop {}
 
-    public struct Owner has store, drop { 
-        updates: u32,
-        addr: Option<address>
-    }
+/// Capability for Discord Application.
+public struct DiscordCap has key, store { id: UID }
 
-    /// A Discord Member profile.
-    public struct Member has store, drop {
-        /// Available points that can be converted into coupon codes. 1 point -> 1% discount.
-        available_points: u64,
-        /// Roles already assigned to a member. Helps us verify we never give the same rewards twice.
-        roles: VecSet<u8>,
-        /// List of coupons claimed by the user.
-        claimed_coupons: vector<String>,
-        /// Mapping of DiscordId -> Address
-        owner: Owner
-    }
+public struct Owner has drop, store {
+    updates: u32,
+    addr: Option<address>,
+}
 
-    /// Discord Shared Object.
-    public struct Discord has key {
-        id: UID,
-        /// A public key, the backend signs messages that this key can verify.
-        public_key: vector<u8>, 
-        /// mapping a roleId -> percentage discount ([0,100]) (Up to 256 roles)
-        discord_roles: VecMap<u8, u8>, 
-        /// DiscordId -> Member
-        users: Table<String, Member>, 
-    }
+/// A Discord Member profile.
+public struct Member has drop, store {
+    /// Available points that can be converted into coupon codes. 1 point -> 1% discount.
+    available_points: u64,
+    /// Roles already assigned to a member. Helps us verify we never give the same rewards twice.
+    roles: VecSet<u8>,
+    /// List of coupons claimed by the user.
+    claimed_coupons: vector<String>,
+    /// Mapping of DiscordId -> Address
+    owner: Owner,
+}
 
-    fun init(ctx: &mut TxContext){
-        transfer::share_object(Discord {
+/// Discord Shared Object.
+public struct Discord has key {
+    id: UID,
+    /// A public key, the backend signs messages that this key can verify.
+    public_key: vector<u8>,
+    /// mapping a roleId -> percentage discount ([0,100]) (Up to 256 roles)
+    discord_roles: VecMap<u8, u8>,
+    /// DiscordId -> Member
+    users: Table<String, Member>,
+}
+
+fun init(ctx: &mut TxContext) {
+    transfer::share_object(Discord {
+        id: object::new(ctx),
+        public_key: vector::empty(),
+        discord_roles: vec_map::empty(),
+        users: table::new(ctx),
+    });
+
+    transfer::transfer(
+        DiscordCap {
             id: object::new(ctx),
-            public_key: vector::empty(),
-            discord_roles: vec_map::empty(),
-            users: table::new(ctx),
-        });
+        },
+        ctx.sender(),
+    );
+}
 
-        transfer::transfer(DiscordCap {
-            id: object::new(ctx)
-        }, ctx.sender());
-    }
+/// A signature protected route, which the BE signs, which allows adding roles.
+/// Can be called by anyone, only works for the { discord_id -> roles[] } mapping.
+public fun attach_roles(
+    discord: &mut Discord,
+    signature: vector<u8>,
+    discord_id: String,
+    roles: vector<u8>,
+) {
+    assert!(discord.public_key.length() > 0, ENoSignatureSet);
+    let mut msg_bytes = vector::empty<u8>();
+    msg_bytes.append(b"roles_");
+    msg_bytes.append(*discord_id.bytes());
+    msg_bytes.append(b"|");
+    msg_bytes.append(roles);
 
-    /// A signature protected route, which the BE signs, which allows adding roles.
-    /// Can be called by anyone, only works for the { discord_id -> roles[] } mapping.
-    public fun attach_roles(discord: &mut Discord, signature: vector<u8>, discord_id: String, roles: vector<u8>) {
-        assert!(discord.public_key.length() > 0, ENoSignatureSet);
-        let mut msg_bytes = vector::empty<u8>();
-        msg_bytes.append(b"roles_");
-        msg_bytes.append(*discord_id.bytes());
-        msg_bytes.append(b"|");
-        msg_bytes.append(roles);
+    // Verify that the signed message is valid.
+    // The signed message should contain a valid `discord_id : roles` mapping
+    assert!(
+        ecdsa_k1::secp256k1_verify(&signature, &discord.public_key, &msg_bytes, 1),
+        ESignatureNotMatch,
+    );
 
-        // Verify that the signed message is valid.
-        // The signed message should contain a valid `discord_id : roles` mapping
-        assert!(ecdsa_k1::secp256k1_verify(&signature, &discord.public_key, &msg_bytes, 1), ESignatureNotMatch);
+    // if the table doesn't contain that discord membership,add it.
+    if (!discord.users.contains(discord_id)) {
+        discord.users.add(discord_id, new_member());
+    };
 
-        // if the table doesn't contain that discord membership,add it.
-        if (!discord.users.contains(discord_id)) {
-            discord.users.add(discord_id, new_member());
-        };
+    let member = discord.users.borrow_mut(discord_id); // borrow a mutable reference.
+    member.add_roles_internal(roles, &discord.discord_roles);
+}
 
-        let member = discord.users.borrow_mut(discord_id); // borrow a mutable reference. 
-        member.add_roles_internal(roles, &discord.discord_roles);
-    }
+/// A function to set the address mapping for a DiscordID <-> Address.
+/// Can be called only by anyone, only works for a specific pair (address -> discordId)
+/// which is signed by the BE.
+public fun set_address(
+    discord: &mut Discord,
+    signature: vector<u8>,
+    discord_id: String,
+    ctx: &TxContext,
+) {
+    assert!(discord.public_key.length() > 0, ENoSignatureSet);
+    let member = if (!discord.users.contains(discord_id)) {
+        discord.users.add(discord_id, new_member());
+        discord.users.borrow_mut(discord_id)
+    } else {
+        discord.users.borrow_mut(discord_id)
+    };
 
-    /// A function to set the address mapping for a DiscordID <-> Address.
-    /// Can be called only by anyone, only works for a specific pair (address -> discordId)
-    /// which is signed by the BE.
-    public fun set_address(discord: &mut Discord, signature: vector<u8>, discord_id: String, ctx: &TxContext) {
-        assert!(discord.public_key.length() > 0, ENoSignatureSet);
-        let member = if (!discord.users.contains(discord_id)) {
-            discord.users.add(discord_id, new_member());
-            discord.users.borrow_mut(discord_id)
-        } else {
-            discord.users.borrow_mut(discord_id)
-        };
+    let updates_count = member.owner.updates;
 
-        let updates_count = member.owner.updates;
+    // set the mapping address!
+    member.owner.addr = option::some(ctx.sender());
+    member.owner.updates = updates_count + 1;
 
-        // set the mapping address!
-        member.owner.addr = option::some(ctx.sender());
-        member.owner.updates = updates_count + 1;
+    let mut msg_bytes = vector::empty<u8>();
+    msg_bytes.append(b"address_");
+    msg_bytes.append(bcs::to_bytes(&updates_count));
+    msg_bytes.append(b"|");
+    msg_bytes.append(*discord_id.bytes());
+    msg_bytes.append(b"|");
+    msg_bytes.append(ctx.sender().to_bytes());
 
-        let mut msg_bytes = vector::empty<u8>();
-        msg_bytes.append(b"address_");
-        msg_bytes.append(bcs::to_bytes(&updates_count));
-        msg_bytes.append(b"|");
-        msg_bytes.append(*discord_id.bytes());
-        msg_bytes.append(b"|");
-        msg_bytes.append(ctx.sender().to_bytes());
+    // verify that the signed message is the address of the user.
+    assert!(
+        ecdsa_k1::secp256k1_verify(&signature, &discord.public_key, &msg_bytes, 1),
+        ESignatureNotMatch,
+    );
+}
 
-        // verify that the signed message is the address of the user.
-        assert!(ecdsa_k1::secp256k1_verify(&signature, &discord.public_key, &msg_bytes, 1), ESignatureNotMatch);
-    }
+/// A user protected function to generate a coupon based on Membership data.
+/// Only claimable if there's a mapping {discord_id -> address (which needs to be the sender)}
+public fun claim_coupon(
+    discord: &mut Discord,
+    suins: &mut SuiNS,
+    discord_id: String,
+    amount: u8,
+    ctx: &mut TxContext,
+) {
+    let coupon_code = discord.claim_coupon_internal(discord_id, amount, ctx);
+    let app = coupon_house::app_data_mut(suins, DiscordApp {});
 
-    /// A user protected function to generate a coupon based on Membership data.
-    /// Only claimable if there's a mapping {discord_id -> address (which needs to be the sender)}
-    public fun claim_coupon(discord: &mut Discord, suins: &mut SuiNS, discord_id: String, amount: u8, ctx: &mut TxContext) {
-        let coupon_code = discord.claim_coupon_internal(discord_id, amount, ctx);
-        let app = coupon_house::app_data_mut(suins, DiscordApp {});
+    // Generates the coupon code.
+    // A percentage off coupon that's only valid for that user, and has 1 claim.
+    coupon_house::app_add_coupon(
+        app,
+        coupon_code,
+        percentage_discount_type(),
+        (amount as u64),
+        rules::new_coupon_rules(
+            option::none(),
+            option::some(1),
+            option::some(ctx.sender()),
+            option::none(),
+            option::some(range::new(1, 1)),
+        ),
+        ctx,
+    );
+}
 
-        // Generates the coupon code.
-        // A percentage off coupon that's only valid for that user, and has 1 claim.
-        coupon_house::app_add_coupon(
-            app,
-            coupon_code, 
-            percentage_discount_type(),
-            (amount as u64),
-            rules::new_coupon_rules(
-                option::none(), // Available for all domain sizes.
-                option::some(1), // Available only for one claim
-                option::some(ctx.sender()), // Specific to the transaction sender.
-                option::none(), // expiration timestamp
-                option::some(range::new(1,1)) // available years -> Only 1 year registrations.
+/// Admin Actions
+public fun set_public_key(_: &DiscordCap, discord: &mut Discord, key: vector<u8>) {
+    assert!(key.length() > 0, EInvalidPublicKey);
+    discord.public_key = key;
+}
+
+/// We allow adding discord roles, but not removing one.
+/// This way we make sure that unique role_ids are mapped per Member.
+/// We can simply ignore (not sign) any messages tht include this role.
+public fun add_discord_role(_: &DiscordCap, discord: &mut Discord, role_id: u8, discount: u8) {
+    // check if discount amount is valid.
+    assert_is_valid_discount(discount);
+    assert!(!discord.discord_roles.contains(&role_id), ERoleAlreadyExists);
+    discord.discord_roles.insert(role_id, discount);
+}
+
+/// discount is in range (0,100]
+public fun assert_is_valid_discount(discount: u8) {
+    assert!(discount > 0 && discount <= 100, EInvalidDiscount);
+}
+
+/// internal function to add roles to a member and save the points.
+/// Aborts if the member already had these roles.
+fun add_roles_internal(member: &mut Member, mut roles: vector<u8>, discord_roles: &VecMap<u8, u8>) {
+    // checks if new roles vector is empty.
+    assert!(!roles.is_empty(), ENoRolesFound);
+
+    while (!roles.is_empty()) {
+        let role = roles.pop_back();
+        // 1. Member shouldn't have this role
+        assert!(!member.roles.contains(&role), ERoleAlreadyAssigned);
+
+        // 2. This role needs to be valid (exist in discord_roles)
+        assert!(discord_roles.contains(&role), ERoleNotExists);
+
+        member.roles.insert(role);
+
+        // add discount to the member's available points. We can cast u8 to u64 safely.
+        member.available_points = member.available_points + (discord_roles[&role] as u64);
+    };
+}
+
+public fun available_points(member: &Member): u64 {
+    member.available_points
+}
+
+public(package) fun member(discord: &Discord, discord_id: String): &Member {
+    discord.users.borrow(discord_id)
+}
+
+/// An internal coupon claim handler that validates data, creates the coupon code, updates membership details
+/// and returns the `coupon_code` to be registered.
+public(package) fun claim_coupon_internal(
+    discord: &mut Discord,
+    discord_id: String,
+    amount: u8,
+    ctx: &TxContext,
+): String {
+    // check the amount asked is valid.
+    assert_is_valid_discount(amount);
+
+    // Verify that the discord_id exists on both the mapping and the users.
+    assert!(discord.users.contains(discord_id), EDiscordIdNotFound);
+
+    // Find the user mapped to that discord id.
+    let mapping = &discord.users[discord_id];
+    assert!(
+        mapping.owner.addr.is_some() && mapping.owner.addr.borrow() == ctx.sender(),
+        EAddressNoMapping,
+    );
+
+    let member = &mut discord.users[discord_id];
+    assert!(member.available_points >= (amount as u64), ENotEnoughPoints);
+
+    // Generate a predictable coupon code
+    // We generate it by the hash(discord_id + total coupons claimed)
+    // so for first it's discord_id+0, second is discord_id+1 ...
+    // That way, we could predict the copon codes off-chain too.
+    let coupon_code = address::from_bytes(
+        hash::blake2b256(
+            &bcs::to_bytes(
+                &vector[
+                    bcs::to_bytes(&discord_id),
+                    bcs::to_bytes(&member.claimed_coupons.length()),
+                ],
             ),
-            ctx
-        );
+        ),
+    ).to_string();
+
+    member.available_points = member.available_points - (amount as u64);
+    member.claimed_coupons.push_back(coupon_code); // save coupon in the users claimed list.
+
+    coupon_code
+}
+
+fun new_member(): Member {
+    Member {
+        available_points: 0,
+        roles: vec_set::empty(),
+        claimed_coupons: vector::empty(),
+        owner: Owner {
+            updates: 0,
+            addr: option::none(),
+        },
     }
+}
 
-    /// Admin Actions
-    public fun set_public_key(_: &DiscordCap, discord: &mut Discord, key: vector<u8>) {
-        assert!(key.length() > 0, EInvalidPublicKey);
-        discord.public_key = key;
-    }
-
-    /// We allow adding discord roles, but not removing one.
-    /// This way we make sure that unique role_ids are mapped per Member.
-    /// We can simply ignore (not sign) any messages tht include this role.
-    public fun add_discord_role(_: &DiscordCap, discord: &mut Discord, role_id: u8, discount: u8) {
-        // check if discount amount is valid.
-        assert_is_valid_discount(discount);
-        assert!(!discord.discord_roles.contains(&role_id), ERoleAlreadyExists);
-        discord.discord_roles.insert(role_id, discount);
-    }
-
-    /// discount is in range (0,100]
-    public fun assert_is_valid_discount(discount: u8) {
-        assert!(discount > 0 && discount <= 100, EInvalidDiscount);
-    }
-
-    /// internal function to add roles to a member and save the points.
-    /// Aborts if the member already had these roles.
-    fun add_roles_internal(member: &mut Member, mut roles: vector<u8>, discord_roles: &VecMap<u8, u8>) {
-        // checks if new roles vector is empty.
-        assert!(!roles.is_empty(), ENoRolesFound);
-
-        while(!roles.is_empty()){
-            let role = roles.pop_back();
-            // 1. Member shouldn't have this role
-            assert!(!member.roles.contains(&role), ERoleAlreadyAssigned);
-
-            // 2. This role needs to be valid (exist in discord_roles)
-            assert!(discord_roles.contains(&role), ERoleNotExists);
-
-            member.roles.insert(role);
-
-            // add discount to the member's available points. We can cast u8 to u64 safely.
-            member.available_points = member.available_points + (discord_roles[&role] as u64);
-        };
-    }
-
-    public fun available_points(member: &Member): u64 {
-        member.available_points
-    }
-
-    public(package) fun member(discord: &Discord, discord_id: String): &Member {
-        discord.users.borrow(discord_id)
-    }
-
-    /// An internal coupon claim handler that validates data, creates the coupon code, updates membership details
-    /// and returns the `coupon_code` to be registered.
-    public(package) fun claim_coupon_internal(discord: &mut Discord, discord_id: String, amount: u8, ctx: &TxContext): String {
-        // check the amount asked is valid.
-        assert_is_valid_discount(amount);
-
-        // Verify that the discord_id exists on both the mapping and the users.
-        assert!(discord.users.contains(discord_id), EDiscordIdNotFound);
-
-        // Find the user mapped to that discord id.
-        let mapping = &discord.users[discord_id];
-        assert!(mapping.owner.addr.is_some() && mapping.owner.addr.borrow() == ctx.sender(), EAddressNoMapping);
-
-        let member = &mut discord.users[discord_id];
-        assert!(member.available_points >= (amount as u64), ENotEnoughPoints);
-
-        // Generate a predictable coupon code
-        // We generate it by the hash(discord_id + total coupons claimed)
-        // so for first it's discord_id+0, second is discord_id+1 ...
-        // That way, we could predict the copon codes off-chain too.
-        let coupon_code = address::from_bytes(
-            hash::blake2b256(
-                &bcs::to_bytes(&vector[bcs::to_bytes(&discord_id), bcs::to_bytes(&member.claimed_coupons.length())
-            ])
-        )).to_string();
-
-        member.available_points = member.available_points - (amount as u64);
-        member.claimed_coupons.push_back(coupon_code); // save coupon in the users claimed list.
-
-        coupon_code
-    }
-
-    fun new_member(): Member {
-        Member {
-            available_points: 0,
-            roles: vec_set::empty(),
-            claimed_coupons: vector::empty(),
-            owner: Owner {
-                updates: 0,
-                addr: option::none()
-            }
-        }
-    }
-
-    #[test_only]
-    public fun init_for_testing(ctx: &mut TxContext) {
-        init(ctx)
-    }
+#[test_only]
+public fun init_for_testing(ctx: &mut TxContext) {
+    init(ctx)
 }

--- a/packages/discord/tests/discord_tests.move
+++ b/packages/discord/tests/discord_tests.move
@@ -2,288 +2,325 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-module discord::discord_tests {
-    use sui::test_scenario::{Self, Scenario};
-    use discord::discord::{Self, Discord, DiscordCap, DiscordApp};
-    use discord::test_payloads::{Self as tp};
-    use coupons::{
-        setup as coupon_setup,
-        coupon_house
+module discord::discord_tests;
+
+use coupons::{coupon_house, setup as coupon_setup};
+use discord::{discord::{Self, Discord, DiscordCap, DiscordApp}, test_payloads as tp};
+use sui::test_scenario::{Self, Scenario};
+use suins::suins::{SuiNS, AdminCap};
+
+const ADMIN_ADDRESS: address = @0xA001;
+
+fun test_init(): Scenario {
+    let mut scenario_val = test_scenario::begin(ADMIN_ADDRESS);
+    let scenario = &mut scenario_val;
+    {
+        discord::init_for_testing(scenario.ctx());
     };
-    use suins::{
-        suins::{SuiNS, AdminCap}
-    };
-
-    const ADMIN_ADDRESS: address = @0xA001;
-
-    fun test_init(): Scenario {
-        let mut scenario_val = test_scenario::begin(ADMIN_ADDRESS);
-        let scenario = &mut scenario_val;
-        {
-            discord::init_for_testing(scenario.ctx());
-        };
-        coupon_setup::initialize_coupon_house(scenario);
-        {
-            scenario.next_tx(ADMIN_ADDRESS);
-            let mut discord = scenario.take_shared<Discord>();
-            // get admin cap
-            let cap = test_scenario::take_from_sender<DiscordCap>(scenario);
-
-            // prepare discord roles
-            cap.add_discord_role(&mut discord, tp::get_nth_role(0), tp::get_nth_role_percentage(0));
-            cap.add_discord_role(&mut discord, tp::get_nth_role(1), tp::get_nth_role_percentage(1));
-            cap.add_discord_role(&mut discord, tp::get_nth_role(2), tp::get_nth_role_percentage(2));
-            cap.add_discord_role(&mut discord, tp::get_nth_role(3), tp::get_nth_role_percentage(3));
-            cap.add_discord_role(&mut discord, tp::get_nth_role(4), tp::get_nth_role_percentage(4));
-
-            cap.set_public_key(&mut discord, tp::get_public_key());
-
-            scenario.return_to_sender(cap);
-            test_scenario::return_shared(discord);
-        };
-        {
-            let admin_cap = scenario.take_from_sender<AdminCap>();
-            let mut suins = scenario.take_shared<SuiNS>();
-            coupon_house::authorize_app<DiscordApp>(&admin_cap, &mut suins);
-            scenario.return_to_sender(admin_cap);
-            test_scenario::return_shared(suins);
-        };
-        scenario_val
-    }
-
-    fun prepare_data(scenario: &mut Scenario) {
-        scenario.next_tx(tp::get_nth_user(0));
+    coupon_setup::initialize_coupon_house(scenario);
+    {
+        scenario.next_tx(ADMIN_ADDRESS);
         let mut discord = scenario.take_shared<Discord>();
+        // get admin cap
+        let cap = test_scenario::take_from_sender<DiscordCap>(scenario);
 
-        discord.attach_roles(tp::get_nth_attach_roles_signature(0), tp::get_nth_discord_id(0), vector[tp::get_nth_role(0), tp::get_nth_role(1)]);
-        discord.attach_roles(tp::get_nth_attach_roles_signature(2), tp::get_nth_discord_id(1), vector[tp::get_nth_role(2), tp::get_nth_role(3)]);
+        // prepare discord roles
+        cap.add_discord_role(&mut discord, tp::get_nth_role(0), tp::get_nth_role_percentage(0));
+        cap.add_discord_role(&mut discord, tp::get_nth_role(1), tp::get_nth_role_percentage(1));
+        cap.add_discord_role(&mut discord, tp::get_nth_role(2), tp::get_nth_role_percentage(2));
+        cap.add_discord_role(&mut discord, tp::get_nth_role(3), tp::get_nth_role_percentage(3));
+        cap.add_discord_role(&mut discord, tp::get_nth_role(4), tp::get_nth_role_percentage(4));
 
-        discord.set_address(tp::get_nth_address_mapping_signature(0), tp::get_nth_discord_id(0), scenario.ctx());
+        cap.set_public_key(&mut discord, tp::get_public_key());
 
-        scenario.next_tx(tp::get_nth_user(1));
-        discord.set_address(tp::get_nth_address_mapping_signature(1), tp::get_nth_discord_id(1), scenario.ctx());
+        scenario.return_to_sender(cap);
         test_scenario::return_shared(discord);
-    }
+    };
+    {
+        let admin_cap = scenario.take_from_sender<AdminCap>();
+        let mut suins = scenario.take_shared<SuiNS>();
+        coupon_house::authorize_app<DiscordApp>(&admin_cap, &mut suins);
+        scenario.return_to_sender(admin_cap);
+        test_scenario::return_shared(suins);
+    };
+    scenario_val
+}
 
-    // test all the flows!
-    #[test]
-    fun test_e2e() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        // prepare data and data mappings!
-        prepare_data(scenario);
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-            let mut suins = scenario.take_shared<SuiNS>();
-            discord.claim_coupon(&mut suins, tp::get_nth_discord_id(0), 50, scenario.ctx());
-            test_scenario::return_shared(discord);
-            test_scenario::return_shared(suins);
-        };
-        {
-            scenario.next_tx(tp::get_nth_user(1));
-            let mut discord = scenario.take_shared<Discord>();
-            let mut suins = scenario.take_shared<SuiNS>();
-            discord.claim_coupon(&mut suins, tp::get_nth_discord_id(1), 100, scenario.ctx());
+fun prepare_data(scenario: &mut Scenario) {
+    scenario.next_tx(tp::get_nth_user(0));
+    let mut discord = scenario.take_shared<Discord>();
 
-            test_scenario::return_shared(discord);
-            test_scenario::return_shared(suins);
-        };
-        {
-            scenario.next_tx(tp::get_nth_user(1));
-            let mut discord = scenario.take_shared<Discord>();
-            let mut suins = scenario.take_shared<SuiNS>();
-            discord.claim_coupon(&mut suins, tp::get_nth_discord_id(1), 40, scenario.ctx());
+    discord.attach_roles(
+        tp::get_nth_attach_roles_signature(0),
+        tp::get_nth_discord_id(0),
+        vector[tp::get_nth_role(0), tp::get_nth_role(1)],
+    );
+    discord.attach_roles(
+        tp::get_nth_attach_roles_signature(2),
+        tp::get_nth_discord_id(1),
+        vector[tp::get_nth_role(2), tp::get_nth_role(3)],
+    );
 
-            test_scenario::return_shared(discord);
-            test_scenario::return_shared(suins);
-        };
-        {
-            scenario.next_tx(tp::get_nth_user(1));
-            let discord = scenario.take_shared<Discord>();
-            let member = discord.member(tp::get_nth_discord_id(1));
-            assert!(member.available_points() == 10, 0);
-            test_scenario::return_shared(discord);
-        };
+    discord.set_address(
+        tp::get_nth_address_mapping_signature(0),
+        tp::get_nth_discord_id(0),
+        scenario.ctx(),
+    );
 
-        scenario_val.end();
-    }
+    scenario.next_tx(tp::get_nth_user(1));
+    discord.set_address(
+        tp::get_nth_address_mapping_signature(1),
+        tp::get_nth_discord_id(1),
+        scenario.ctx(),
+    );
+    test_scenario::return_shared(discord);
+}
 
-    #[test, expected_failure(abort_code=::discord::discord::ESignatureNotMatch)]
-    fun attach_roles_to_wrong_discord_id_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-            discord.attach_roles(tp::get_nth_attach_roles_signature(0), tp::get_nth_discord_id(1), vector[tp::get_nth_role(0), tp::get_nth_role(1)]);
-            test_scenario::return_shared(discord);
-        };
-        scenario_val.end();
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::ESignatureNotMatch)]
-    fun attach_invalid_roles_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-            discord.attach_roles(tp::get_nth_attach_roles_signature(0), tp::get_nth_discord_id(0), vector[tp::get_nth_role(1), tp::get_nth_role(2)]);
-            test_scenario::return_shared(discord);
-        };
-        scenario_val.end();
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::ERoleAlreadyAssigned)]
-    fun try_to_attach_role_twice_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-
-            discord.attach_roles(tp::get_nth_attach_roles_signature(0), tp::get_nth_discord_id(0), vector[tp::get_nth_role(0), tp::get_nth_role(1)]);
-            discord.attach_roles(tp::get_nth_attach_roles_signature(1), tp::get_nth_discord_id(0), vector[tp::get_nth_role(1), tp::get_nth_role(3)]);
-    
-            test_scenario::return_shared(discord);
-        };
-        // let scenario = &mut scenario_val;
-        scenario_val.end();
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::ERoleNotExists)]
-    fun try_to_attach_non_existing_role_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-
-            discord.attach_roles(tp::get_nth_attach_roles_signature(3), tp::get_nth_discord_id(1), vector[5]);
-            test_scenario::return_shared(discord);
-        };
-        // let scenario = &mut scenario_val;
-        scenario_val.end();
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::ESignatureNotMatch)]
-    fun try_to_attach_address_to_invalid_discord_id_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        {
-            scenario.next_tx(tp::get_nth_user(1));
-            let mut discord = scenario.take_shared<Discord>();
-
-            discord.set_address(tp::get_nth_address_mapping_signature(0), tp::get_nth_discord_id(0), scenario.ctx());
-            test_scenario::return_shared(discord);
-        };
-        // let scenario = &mut scenario_val;
-        scenario_val.end();
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::ESignatureNotMatch)]
-    fun try_to_reuse_signature_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        prepare_data(scenario);
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-
-            discord.set_address(tp::get_nth_address_mapping_signature(0), tp::get_nth_discord_id(0), scenario.ctx());
-            test_scenario::return_shared(discord);
-        };
-        scenario_val.end();
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::ENotEnoughPoints)]
-    fun claim_more_points_than_available_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        prepare_data(scenario);
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-            discord.claim_coupon_internal(tp::get_nth_discord_id(0), 60, scenario.ctx());
-
-            test_scenario::return_shared(discord);
-        };
-        scenario_val.end();
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::ENotEnoughPoints)]
-    fun claim_more_points_in_two_steps_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        prepare_data(scenario);
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-            discord.claim_coupon_internal(tp::get_nth_discord_id(0), 45, scenario.ctx());
-            test_scenario::return_shared(discord);
-        };
-        {
-            scenario.next_tx(tp::get_nth_user(0));
-            let mut discord = scenario.take_shared<Discord>();
-            discord.claim_coupon_internal(tp::get_nth_discord_id(0), 6, scenario.ctx());
-        };
-        abort 1337
-    }
-
-
-    #[test, expected_failure(abort_code=::discord::discord::EInvalidDiscount)]
-    fun claim_with_invalid_percentage_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        prepare_data(scenario);
-        scenario.next_tx(tp::get_nth_user(1));
-        let mut discord = scenario.take_shared<Discord>();
-        discord.claim_coupon_internal(tp::get_nth_discord_id(1), 110, scenario.ctx());
-
-        abort 1337
-    }
-
-    #[test, expected_failure(abort_code=::discord::discord::EAddressNoMapping)]
-    fun claim_with_non_existing_user_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        prepare_data(scenario);
-
-        scenario.next_tx(tp::get_nth_user(1));
-        let mut discord = scenario.take_shared<Discord>();
-        discord.claim_coupon_internal(tp::get_nth_discord_id(0), 50, scenario.ctx());
-
-        abort 1337
-    }
-
-    #[test, expected_failure(abort_code = ::discord::discord::EAddressNoMapping)]
-    fun claim_with_invalid_user_failure() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        // prepare data and data mappings!
-        prepare_data(scenario);
-
+// test all the flows!
+#[test]
+fun test_e2e() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    // prepare data and data mappings!
+    prepare_data(scenario);
+    {
         scenario.next_tx(tp::get_nth_user(0));
         let mut discord = scenario.take_shared<Discord>();
         let mut suins = scenario.take_shared<SuiNS>();
-        discord.claim_coupon(&mut suins, tp::get_nth_discord_id(1), 50, scenario.ctx());
-
-        abort 1337
-    }
-
-    #[test, expected_failure(abort_code = ::discord::discord::EDiscordIdNotFound)]
-    fun claim_non_existent_discord_id() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        // prepare data and data mappings!
-        prepare_data(scenario);
-    
-        scenario.next_tx(tp::get_nth_user(0));
+        discord.claim_coupon(&mut suins, tp::get_nth_discord_id(0), 50, scenario.ctx());
+        test_scenario::return_shared(discord);
+        test_scenario::return_shared(suins);
+    };
+    {
+        scenario.next_tx(tp::get_nth_user(1));
         let mut discord = scenario.take_shared<Discord>();
         let mut suins = scenario.take_shared<SuiNS>();
-        discord.claim_coupon(&mut suins, b"non_existent".to_string(), 50, scenario.ctx());
+        discord.claim_coupon(&mut suins, tp::get_nth_discord_id(1), 100, scenario.ctx());
 
-        abort 1337
-    }
+        test_scenario::return_shared(discord);
+        test_scenario::return_shared(suins);
+    };
+    {
+        scenario.next_tx(tp::get_nth_user(1));
+        let mut discord = scenario.take_shared<Discord>();
+        let mut suins = scenario.take_shared<SuiNS>();
+        discord.claim_coupon(&mut suins, tp::get_nth_discord_id(1), 40, scenario.ctx());
+
+        test_scenario::return_shared(discord);
+        test_scenario::return_shared(suins);
+    };
+    {
+        scenario.next_tx(tp::get_nth_user(1));
+        let discord = scenario.take_shared<Discord>();
+        let member = discord.member(tp::get_nth_discord_id(1));
+        assert!(member.available_points() == 10, 0);
+        test_scenario::return_shared(discord);
+    };
+
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ESignatureNotMatch)]
+fun attach_roles_to_wrong_discord_id_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+        discord.attach_roles(
+            tp::get_nth_attach_roles_signature(0),
+            tp::get_nth_discord_id(1),
+            vector[tp::get_nth_role(0), tp::get_nth_role(1)],
+        );
+        test_scenario::return_shared(discord);
+    };
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ESignatureNotMatch)]
+fun attach_invalid_roles_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+        discord.attach_roles(
+            tp::get_nth_attach_roles_signature(0),
+            tp::get_nth_discord_id(0),
+            vector[tp::get_nth_role(1), tp::get_nth_role(2)],
+        );
+        test_scenario::return_shared(discord);
+    };
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ERoleAlreadyAssigned)]
+fun try_to_attach_role_twice_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+
+        discord.attach_roles(
+            tp::get_nth_attach_roles_signature(0),
+            tp::get_nth_discord_id(0),
+            vector[tp::get_nth_role(0), tp::get_nth_role(1)],
+        );
+        discord.attach_roles(
+            tp::get_nth_attach_roles_signature(1),
+            tp::get_nth_discord_id(0),
+            vector[tp::get_nth_role(1), tp::get_nth_role(3)],
+        );
+
+        test_scenario::return_shared(discord);
+    };
+    // let scenario = &mut scenario_val;
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ERoleNotExists)]
+fun try_to_attach_non_existing_role_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+
+        discord.attach_roles(
+            tp::get_nth_attach_roles_signature(3),
+            tp::get_nth_discord_id(1),
+            vector[5],
+        );
+        test_scenario::return_shared(discord);
+    };
+    // let scenario = &mut scenario_val;
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ESignatureNotMatch)]
+fun try_to_attach_address_to_invalid_discord_id_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    {
+        scenario.next_tx(tp::get_nth_user(1));
+        let mut discord = scenario.take_shared<Discord>();
+
+        discord.set_address(
+            tp::get_nth_address_mapping_signature(0),
+            tp::get_nth_discord_id(0),
+            scenario.ctx(),
+        );
+        test_scenario::return_shared(discord);
+    };
+    // let scenario = &mut scenario_val;
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ESignatureNotMatch)]
+fun try_to_reuse_signature_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    prepare_data(scenario);
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+
+        discord.set_address(
+            tp::get_nth_address_mapping_signature(0),
+            tp::get_nth_discord_id(0),
+            scenario.ctx(),
+        );
+        test_scenario::return_shared(discord);
+    };
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ENotEnoughPoints)]
+fun claim_more_points_than_available_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    prepare_data(scenario);
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+        discord.claim_coupon_internal(tp::get_nth_discord_id(0), 60, scenario.ctx());
+
+        test_scenario::return_shared(discord);
+    };
+    scenario_val.end();
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::ENotEnoughPoints)]
+fun claim_more_points_in_two_steps_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    prepare_data(scenario);
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+        discord.claim_coupon_internal(tp::get_nth_discord_id(0), 45, scenario.ctx());
+        test_scenario::return_shared(discord);
+    };
+    {
+        scenario.next_tx(tp::get_nth_user(0));
+        let mut discord = scenario.take_shared<Discord>();
+        discord.claim_coupon_internal(tp::get_nth_discord_id(0), 6, scenario.ctx());
+    };
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::EInvalidDiscount)]
+fun claim_with_invalid_percentage_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    prepare_data(scenario);
+    scenario.next_tx(tp::get_nth_user(1));
+    let mut discord = scenario.take_shared<Discord>();
+    discord.claim_coupon_internal(tp::get_nth_discord_id(1), 110, scenario.ctx());
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::EAddressNoMapping)]
+fun claim_with_non_existing_user_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    prepare_data(scenario);
+
+    scenario.next_tx(tp::get_nth_user(1));
+    let mut discord = scenario.take_shared<Discord>();
+    discord.claim_coupon_internal(tp::get_nth_discord_id(0), 50, scenario.ctx());
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::EAddressNoMapping)]
+fun claim_with_invalid_user_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    // prepare data and data mappings!
+    prepare_data(scenario);
+
+    scenario.next_tx(tp::get_nth_user(0));
+    let mut discord = scenario.take_shared<Discord>();
+    let mut suins = scenario.take_shared<SuiNS>();
+    discord.claim_coupon(&mut suins, tp::get_nth_discord_id(1), 50, scenario.ctx());
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::discord::discord::EDiscordIdNotFound)]
+fun claim_non_existent_discord_id() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    // prepare data and data mappings!
+    prepare_data(scenario);
+
+    scenario.next_tx(tp::get_nth_user(0));
+    let mut discord = scenario.take_shared<Discord>();
+    let mut suins = scenario.take_shared<SuiNS>();
+    discord.claim_coupon(&mut suins, b"non_existent".to_string(), 50, scenario.ctx());
+
+    abort 1337
 }

--- a/packages/discord/tests/test_payloads.move
+++ b/packages/discord/tests/test_payloads.move
@@ -2,75 +2,78 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-module discord::test_payloads{
-    use std::string::{String, utf8};
-    
-    // This Private & Public Key are used only for the tests.
-    // DO NOT USE FOR ANY OTHER USE-CASE.
-    // The signatures were generated manually using them.
-    const PUBLIC_KEY: vector<u8> = vector[
-        4,177,184,19,176,151,134,25,40,7,168,22,178,146,103,231,118,184,226,112,30,112,60,79,82,48,21,178,230,245,196,0,33,215,72,73,76,69,45,51,238,183,5,116,103,167,55,47,141,122,164,235,152,113,12,66,220,0,89,40,222,144,54,204,180
-    ];
+module discord::test_payloads;
 
-    // const PRIVATE_KEY: vector<u8> = vector[
-    //     41,57,20,16,48,176,168,150,45,108,210,160,72,179,198,136,55,154,99,223,169,111,177,151,119,241,163,34,227,94,174,212
-    // ];
+use std::string::{String, utf8};
 
-    // some sample roles & percentages
-    const ROLES: vector<u8> = vector[0,1,2,3,4];
-    const PERCENTAGES: vector<u8> = vector[20,30,100,50,60];
+// This Private & Public Key are used only for the tests.
+// DO NOT USE FOR ANY OTHER USE-CASE.
+// The signatures were generated manually using them.
+const PUBLIC_KEY: vector<u8> = vector[
+    4, 177, 184, 19, 176, 151, 134, 25, 40, 7, 168, 22, 178, 146, 103, 231, 118, 184, 226, 112, 30,
+    112, 60, 79, 82, 48, 21, 178, 230, 245, 196, 0, 33, 215, 72, 73, 76, 69, 45, 51, 238, 183, 5,
+    116, 103, 167, 55, 47, 141, 122, 164, 235, 152, 113, 12, 66, 220, 0, 89, 40, 222, 144, 54, 204,
+    180,
+];
 
-    const ADDRESSES: vector<address> = vector[@0x5, @0x6, @0x7];
-    const DISCORD_IDS: vector<vector<u8>> = vector[b"discord_id_1", b"discord_id_2"];
+// const PRIVATE_KEY: vector<u8> = vector[
+//     41,57,20,16,48,176,168,150,45,108,210,160,72,179,198,136,55,154,99,223,169,111,177,151,119,241,163,34,227,94,174,212
+// ];
 
-    public fun get_public_key(): vector<u8>{
-        PUBLIC_KEY
-    }
+// some sample roles & percentages
+const ROLES: vector<u8> = vector[0, 1, 2, 3, 4];
+const PERCENTAGES: vector<u8> = vector[20, 30, 100, 50, 60];
 
-    public fun get_nth_user(i: u64): address {
-        ADDRESSES[i]
-    }
+const ADDRESSES: vector<address> = vector[@0x5, @0x6, @0x7];
+const DISCORD_IDS: vector<vector<u8>> = vector[b"discord_id_1", b"discord_id_2"];
 
-    public fun get_nth_role(i: u64): u8 {
-        ROLES[i]
-    }
+public fun get_public_key(): vector<u8> {
+    PUBLIC_KEY
+}
 
-    public fun get_nth_role_percentage(i: u64): u8 {
-        PERCENTAGES[i]
-    }
+public fun get_nth_user(i: u64): address {
+    ADDRESSES[i]
+}
 
-    public fun get_nth_discord_id(i: u64): String {
-        utf8(DISCORD_IDS[i])
-    }
+public fun get_nth_role(i: u64): u8 {
+    ROLES[i]
+}
 
-    // A list of singed messages.
+public fun get_nth_role_percentage(i: u64): u8 {
+    PERCENTAGES[i]
+}
 
-    // index 0: discord_id_1 + [0,1] roles -> discord_id_1 has maximum of 50% discount.
-    // index 1: discord_id_1 + [1,3] roles (check overlap abort)
-    // index 2: discord_id_2 + [2,3] roles -> discord_id_2 has maximum of 150% discount.
-    // index 3: discord_id_2 + [5] roles (check non-existing role addition)
-    const SIGNED_MESSAGES: vector<vector<u8>> = vector[
-        vector[105,42,23,89,169,88,11,179,47,36,192,254,188,47,205,43,5,90,189,216,117,222,85,208,79,123,27,171,178,110,210,142,27,129,237,16,104,239,13,206,187,126,182,105,229,110,242,43,61,54,47,120,174,109,238,112,3,8,53,248,7,65,161,16],
-        vector[248,231,188,11,131,135,248,201,97,171,85,72,55,165,16,68,92,57,84,25,8,231,162,243,118,206,152,133,149,226,104,184,41,90,23,72,125,111,104,152,228,203,249,100,56,128,178,251,96,48,109,242,211,231,221,187,2,220,156,191,92,216,80,218],
-        vector[196,231,220,181,211,72,131,106,104,57,169,215,200,90,59,133,174,90,31,246,244,208,155,167,96,207,12,45,136,251,218,19,20,190,111,206,120,229,183,107,199,124,76,93,104,9,75,230,150,250,98,127,126,48,155,184,135,56,47,17,105,213,82,133],
-        vector[141,172,35,213,222,139,7,252,39,254,225,93,172,118,29,178,146,153,7,74,9,229,17,196,203,118,95,84,44,59,214,158,71,103,95,137,177,133,109,65,241,62,189,160,31,134,32,176,43,161,67,172,189,167,250,140,139,154,163,132,30,219,172,57],
-    ];
+public fun get_nth_discord_id(i: u64): String {
+    utf8(DISCORD_IDS[i])
+}
 
-    // mapping between discord_id -> address
-    // index 0: discord_id_1 : 0x5
-    // index2:  discord_id_2 : 0x6
-    const ADDRESS_MAPPING_SIGNATURES: vector<vector<u8>> = vector[
-        vector[222,90,232,68,190,121,104,148,106,213,78,28,141,55,222,243,174,154,53,58,151,69,5,1,73,8,132,152,80,96,24,244,125,215,21,11,156,197,57,150,233,59,81,36,33,59,212,79,134,160,114,9,19,30,145,38,211,61,29,8,221,108,29,144],
-        vector[170,142,191,35,165,75,154,136,163,51,150,87,228,232,189,66,214,110,135,104,20,120,205,137,104,57,203,43,5,189,67,218,94,253,147,138,234,230,166,190,246,163,16,202,10,28,198,64,1,165,133,75,183,179,88,186,181,7,164,238,97,22,74,190]
-    ];
+// A list of singed messages.
 
+// index 0: discord_id_1 + [0,1] roles -> discord_id_1 has maximum of 50% discount.
+// index 1: discord_id_1 + [1,3] roles (check overlap abort)
+// index 2: discord_id_2 + [2,3] roles -> discord_id_2 has maximum of 150% discount.
+// index 3: discord_id_2 + [5] roles (check non-existing role addition)
+// prettier-ignore
+const SIGNED_MESSAGES: vector<vector<u8>> = vector[
+    vector[105,42,23,89,169,88,11,179,47,36,192,254,188,47,205,43,5,90,189,216,117,222,85,208,79,123,27,171,178,110,210,142,27,129,237,16,104,239,13,206,187,126,182,105,229,110,242,43,61,54,47,120,174,109,238,112,3,8,53,248,7,65,161,16],
+    vector[248,231,188,11,131,135,248,201,97,171,85,72,55,165,16,68,92,57,84,25,8,231,162,243,118,206,152,133,149,226,104,184,41,90,23,72,125,111,104,152,228,203,249,100,56,128,178,251,96,48,109,242,211,231,221,187,2,220,156,191,92,216,80,218],
+    vector[196,231,220,181,211,72,131,106,104,57,169,215,200,90,59,133,174,90,31,246,244,208,155,167,96,207,12,45,136,251,218,19,20,190,111,206,120,229,183,107,199,124,76,93,104,9,75,230,150,250,98,127,126,48,155,184,135,56,47,17,105,213,82,133],
+    vector[141,172,35,213,222,139,7,252,39,254,225,93,172,118,29,178,146,153,7,74,9,229,17,196,203,118,95,84,44,59,214,158,71,103,95,137,177,133,109,65,241,62,189,160,31,134,32,176,43,161,67,172,189,167,250,140,139,154,163,132,30,219,172,57],
+];
 
-    public fun get_nth_attach_roles_signature(i: u64): vector<u8> {
-        SIGNED_MESSAGES[i]
-    }
+// mapping between discord_id -> address
+// index 0: discord_id_1 : 0x5
+// index2:  discord_id_2 : 0x6
+// prettier-ignore
+const ADDRESS_MAPPING_SIGNATURES: vector<vector<u8>> = vector[
+    vector[222,90,232,68,190,121,104,148,106,213,78,28,141,55,222,243,174,154,53,58,151,69,5,1,73,8,132,152,80,96,24,244,125,215,21,11,156,197,57,150,233,59,81,36,33,59,212,79,134,160,114,9,19,30,145,38,211,61,29,8,221,108,29,144],
+    vector[170,142,191,35,165,75,154,136,163,51,150,87,228,232,189,66,214,110,135,104,20,120,205,137,104,57,203,43,5,189,67,218,94,253,147,138,234,230,166,190,246,163,16,202,10,28,198,64,1,165,133,75,183,179,88,186,181,7,164,238,97,22,74,190]
+];
 
-    public fun get_nth_address_mapping_signature(i: u64): vector<u8> {
-        ADDRESS_MAPPING_SIGNATURES[i]
-    }
+public fun get_nth_attach_roles_signature(i: u64): vector<u8> {
+    SIGNED_MESSAGES[i]
+}
 
+public fun get_nth_address_mapping_signature(i: u64): vector<u8> {
+    ADDRESS_MAPPING_SIGNATURES[i]
 }

--- a/packages/discounts/sources/discounts.move
+++ b/packages/discounts/sources/discounts.move
@@ -14,9 +14,7 @@ use day_one::day_one::{DayOne, is_active};
 use discounts::house::{Self, DiscountHouse};
 use std::type_name;
 use sui::dynamic_field as df;
-use suins::payment::PaymentIntent;
-use suins::pricing_config::PricingConfig;
-use suins::suins::{AdminCap, SuiNS};
+use suins::{payment::PaymentIntent, pricing_config::PricingConfig, suins::{AdminCap, SuiNS}};
 
 use fun internal_apply_discount as DiscountHouse.internal_apply_discount;
 use fun assert_config_exists as DiscountHouse.assert_config_exists;
@@ -41,7 +39,7 @@ const ENotValidForDayOne: vector<u8> = b"DayOne is not valid for this type";
 public struct RegularDiscountsApp() has drop;
 
 /// A key that determins the discounts for a type `T`.
-public struct DiscountKey<phantom T>() has copy, store, drop;
+public struct DiscountKey<phantom T>() has copy, drop, store;
 
 /// A function to register a name with a discount using type `T`.
 public fun apply_percentage_discount<T>(
@@ -54,10 +52,7 @@ public fun apply_percentage_discount<T>(
     // We can only use this discount for types other than DayOne, because we
     // always check
     // that the `DayOne` object is active.
-    assert!(
-        type_name::get<T>() != type_name::get<DayOne>(),
-        ENotValidForDayOne,
-    );
+    assert!(type_name::get<T>() != type_name::get<DayOne>(), ENotValidForDayOne);
 
     self.internal_apply_discount<T>(intent, suins, ctx);
 }
@@ -136,8 +131,5 @@ fun config<T>(self: &mut DiscountHouse): &PricingConfig {
 }
 
 fun assert_config_exists<T>(self: &mut DiscountHouse) {
-    assert!(
-        self.uid_mut().exists_with_type<_, PricingConfig>(DiscountKey<T>()),
-        EConfigNotExists,
-    );
+    assert!(self.uid_mut().exists_with_type<_, PricingConfig>(DiscountKey<T>()), EConfigNotExists);
 }

--- a/packages/payments/tests/payments_tests.move
+++ b/packages/payments/tests/payments_tests.move
@@ -4,23 +4,20 @@
 #[test_only]
 module payments::payments_tests;
 
-use payments::payments::{
-    new_payments_config,
-    new_coin_type_data,
-    handle_base_payment,
-    PaymentsApp,
-    PaymentsConfig
+use payments::{
+    payments::{
+        new_payments_config,
+        new_coin_type_data,
+        handle_base_payment,
+        PaymentsApp,
+        PaymentsConfig
+    },
+    testns::TESTNS,
+    testusdc::TESTUSDC
 };
-use payments::testns::TESTNS;
-use payments::testusdc::TESTUSDC;
-use std::string::utf8;
-use std::type_name;
-use sui::coin::{Self, CoinMetadata};
-use sui::test_scenario::{Self as ts, ctx};
-use sui::test_utils::destroy;
-use suins::payment;
-use suins::payment_tests::setup_suins;
-use suins::suins::{Self, SuiNS, AdminCap};
+use std::{string::utf8, type_name};
+use sui::{coin::{Self, CoinMetadata}, test_scenario::{Self as ts, ctx}, test_utils::destroy};
+use suins::{payment, payment_tests::setup_suins, suins::{Self, SuiNS, AdminCap}};
 
 public struct PaymentTestsCurrency has drop {}
 public struct SPAM has drop {}
@@ -38,12 +35,7 @@ public fun setup(ctx: &mut TxContext): (SuiNS, AdminCap) {
     (suins, admin_cap)
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::payments::payments::EBaseCurrencySetupMissing,
-    ),
-]
+#[test, expected_failure(abort_code = ::payments::payments::EBaseCurrencySetupMissing)]
 fun base_currency_not_in_list_e() {
     let mut test = ts::begin(SUINS_ADDRESS);
     let (_suins, _admin_cap) = setup(test.ctx());
@@ -67,12 +59,7 @@ fun base_currency_not_in_list_e() {
     abort 1337
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::payments::payments::EInsufficientPayment,
-    ),
-]
+#[test, expected_failure(abort_code = ::payments::payments::EInsufficientPayment)]
 fun payment_insufficient_e() {
     let mut test = ts::begin(SUINS_ADDRESS);
     let (mut suins, admin_cap) = setup(test.ctx());
@@ -111,12 +98,7 @@ fun payment_insufficient_e() {
     abort 1337
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::payments::payments::EInvalidPaymentType,
-    ),
-]
+#[test, expected_failure(abort_code = ::payments::payments::EInvalidPaymentType)]
 fun invalid_payment_type_e() {
     let mut test = ts::begin(SUINS_ADDRESS);
     let (mut suins, admin_cap) = setup(test.ctx());

--- a/packages/subdomains/sources/config.move
+++ b/packages/subdomains/sources/config.move
@@ -1,99 +1,97 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module subdomains::config {
-    use std::string::String;
+module subdomains::config;
 
-    use suins::{domain::{Domain, is_parent_of}, constants::sui_tld};
+use std::string::String;
+use suins::{constants::sui_tld, domain::{Domain, is_parent_of}};
 
-    /// the minimum size a subdomain label can have.
-    const MIN_LABEL_SIZE: u8 = 3;
-    /// the maximum depth a subdomain can have -> 8 (+ 2 for TLD, SLD)
-    const MAX_SUBDOMAIN_DEPTH: u8 = 10;
-     /// Minimum duration for a subdomain in milliseconds. (1 day)
-    const MINIMUM_SUBDOMAIN_DURATION: u64 = 24 * 60 * 60 * 1000;
+/// the minimum size a subdomain label can have.
+const MIN_LABEL_SIZE: u8 = 3;
+/// the maximum depth a subdomain can have -> 8 (+ 2 for TLD, SLD)
+const MAX_SUBDOMAIN_DEPTH: u8 = 10;
+/// Minimum duration for a subdomain in milliseconds. (1 day)
+const MINIMUM_SUBDOMAIN_DURATION: u64 = 24 * 60 * 60 * 1000;
 
-    /// tries to register a subdomain with a depth more than the one allowed.
-    const EDepthOutOfLimit: u64 = 1;
-    /// tries to register a subdomain with the wrong parent (based on name)
-    const EInvalidParent: u64 = 2;
-    /// tries to register a label of size less than 3.
-    const EInvalidLabelSize: u64 = 3;
-    /// tries to register a domain with an unsupported tld.
-    const ENotSupportedTLD: u64 = 4;
+/// tries to register a subdomain with a depth more than the one allowed.
+const EDepthOutOfLimit: u64 = 1;
+/// tries to register a subdomain with the wrong parent (based on name)
+const EInvalidParent: u64 = 2;
+/// tries to register a label of size less than 3.
+const EInvalidLabelSize: u64 = 3;
+/// tries to register a domain with an unsupported tld.
+const ENotSupportedTLD: u64 = 4;
 
-    /// A Subdomain configuration object.
-    /// Holds the allow-listed tlds, the max depth and the minimum label size.
-    public struct SubDomainConfig has copy, store, drop {
-        allowed_tlds: vector<String>,
-        max_depth: u8,
-        min_label_size: u8,
-        minimum_duration: u64
+/// A Subdomain configuration object.
+/// Holds the allow-listed tlds, the max depth and the minimum label size.
+public struct SubDomainConfig has copy, drop, store {
+    allowed_tlds: vector<String>,
+    max_depth: u8,
+    min_label_size: u8,
+    minimum_duration: u64,
+}
+
+public fun default(): SubDomainConfig {
+    SubDomainConfig {
+        allowed_tlds: vector[sui_tld()],
+        max_depth: MAX_SUBDOMAIN_DEPTH,
+        min_label_size: MIN_LABEL_SIZE,
+        minimum_duration: MINIMUM_SUBDOMAIN_DURATION,
     }
+}
 
-    public fun default(): SubDomainConfig {
-        SubDomainConfig {
-            allowed_tlds: vector[sui_tld()],
-            max_depth: MAX_SUBDOMAIN_DEPTH,
-            min_label_size: MIN_LABEL_SIZE,
-            minimum_duration: MINIMUM_SUBDOMAIN_DURATION
-        }
+// Generates a custom config for Subdomains.
+public fun new(
+    allowed_tlds: vector<String>,
+    max_depth: u8,
+    min_label_size: u8,
+    minimum_duration: u64,
+): SubDomainConfig {
+    SubDomainConfig {
+        allowed_tlds,
+        max_depth,
+        min_label_size,
+        minimum_duration,
     }
+}
 
-    // Generates a custom config for Subdomains.
-    public fun new(
-        allowed_tlds: vector<String>,
-        max_depth: u8,
-        min_label_size: u8,
-        minimum_duration: u64
-    ): SubDomainConfig {
-        SubDomainConfig {
-            allowed_tlds,
-            max_depth,
-            min_label_size,
-            minimum_duration
-        }
-    }
+/// Validates that the child name is a valid child for parent.
+public fun assert_is_valid_subdomain(parent: &Domain, child: &Domain, config: &SubDomainConfig) {
+    assert!(is_valid_tld(child, config), ENotSupportedTLD);
+    assert!(is_valid_label(child, config), EInvalidLabelSize);
+    assert!(has_valid_depth(child, config), EDepthOutOfLimit);
+    assert!(is_parent_of(parent, child), EInvalidParent);
+}
 
-    /// Validates that the child name is a valid child for parent.
-    public fun assert_is_valid_subdomain(parent: &Domain, child: &Domain, config: &SubDomainConfig) {
-        assert!(is_valid_tld(child, config), ENotSupportedTLD);
-        assert!(is_valid_label(child, config), EInvalidLabelSize);
-        assert!(has_valid_depth(child, config), EDepthOutOfLimit);
-        assert!(is_parent_of(parent, child), EInvalidParent);
-    }
+public fun minimum_duration(config: &SubDomainConfig): u64 {
+    config.minimum_duration
+}
 
-    public fun minimum_duration(config: &SubDomainConfig): u64 {
-        config.minimum_duration
-    }
+/// Validate that the depth of the subdomain is with the allowed range.
+public fun has_valid_depth(domain: &Domain, config: &SubDomainConfig): bool {
+    domain.number_of_levels() <= (config.max_depth as u64)
+}
 
-    /// Validate that the depth of the subdomain is with the allowed range.
-    public fun has_valid_depth(domain: &Domain, config: &SubDomainConfig): bool {
-        domain.number_of_levels() <= (config.max_depth as u64)
-    }
-
-    /// Validates that the TLD of the domain is supported for subdomains.
-    /// In the beginning, only .sui names will be supported but we might 
-    /// want to add support for others (or not allow).
-    /// (E.g., with `.move` service, we might want to restrict how subdomains are created)
-    public fun is_valid_tld(domain: &Domain, config: &SubDomainConfig): bool {
-        let mut i=0;
-        while (i < config.allowed_tlds.length()) {
-            if (domain.tld() == &config.allowed_tlds[i]) {
-                return true
-            };
-            i = i + 1;
+/// Validates that the TLD of the domain is supported for subdomains.
+/// In the beginning, only .sui names will be supported but we might
+/// want to add support for others (or not allow).
+/// (E.g., with `.move` service, we might want to restrict how subdomains are created)
+public fun is_valid_tld(domain: &Domain, config: &SubDomainConfig): bool {
+    let mut i = 0;
+    while (i < config.allowed_tlds.length()) {
+        if (domain.tld() == &config.allowed_tlds[i]) {
+            return true
         };
-        return false
-    }
+        i = i + 1;
+    };
+    return false
+}
 
-    /// Validate that the subdomain label (e.g. `sub` in `sub.example.sui`) is valid.
-    /// We do not need to check for max length (64), as this is already checked 
-    /// in the `Domain` construction.
-    public fun is_valid_label(domain: &Domain, config: &SubDomainConfig): bool {
-        // our label is the last vector element, as labels are stored in reverse order.
-        let label = domain.label(domain.number_of_levels() - 1);
-        label.length() >= (config.min_label_size as u64)
-    }
-
+/// Validate that the subdomain label (e.g. `sub` in `sub.example.sui`) is valid.
+/// We do not need to check for max length (64), as this is already checked
+/// in the `Domain` construction.
+public fun is_valid_label(domain: &Domain, config: &SubDomainConfig): bool {
+    // our label is the last vector element, as labels are stored in reverse order.
+    let label = domain.label(domain.number_of_levels() - 1);
+    label.length() >= (config.min_label_size as u64)
 }

--- a/packages/subdomains/sources/subdomains.move
+++ b/packages/subdomains/sources/subdomains.move
@@ -2,354 +2,353 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// A registration module for subdomains.
-/// 
+///
 /// This module is responsible for creating subdomains and managing their settings.
-/// 
+///
 /// It allows the following functionality:
-/// 
+///
 /// 1. Registering a new subdomain as a holder of Parent NFT.
 /// 2. Setup the subdomain with capabilities (creating nested names, extending to parent's renewal time).
 /// 3. Registering `leaf` names (whose parent acts as the Capability holder)
 /// 4. Removing `leaf` names
 /// 5. Extending a subdomain expiration's time
 /// 6. Burning expired subdomain NFTs.
-/// 
+///
 /// Comments:
-/// 
+///
 /// 1. By attaching the creation/extension attributes as metadata to the subdomain's NameRecord, we can easily
 /// turn off this package completely, and retain the state on a different package's deployment. This is useful
 /// both for effort-less upgradeability and gas savings.
 /// 2. For any `registry_mut` call, we know that if this module is not authorized, we'll get an abort
 /// from the core suins package.
-/// 
-module subdomains::subdomains {
-    use std::string::{String, utf8};
+///
+module subdomains::subdomains;
 
-    use sui::{clock::Clock, dynamic_field as df, vec_map::VecMap};
+use denylist::denylist;
+use std::string::{String, utf8};
+use subdomains::config::{Self, SubDomainConfig};
+use sui::{clock::Clock, dynamic_field as df, vec_map::VecMap};
+use suins::{
+    constants::{subdomain_allow_extension_key, subdomain_allow_creation_key},
+    domain::{Self, Domain, is_subdomain},
+    registry::Registry,
+    subdomain_registration::SubDomainRegistration,
+    suins::{Self, SuiNS},
+    suins_registration::SuinsRegistration
+};
 
-    use suins::{
-        domain::{Self, Domain, is_subdomain}, 
-        registry::Registry, 
-        suins::{Self, SuiNS}, 
-        suins_registration::SuinsRegistration, 
-        subdomain_registration::SubDomainRegistration, 
-        constants::{subdomain_allow_extension_key, subdomain_allow_creation_key}
+/// Tries to create a subdomain that expires later than the parent or below the minimum.
+const EInvalidExpirationDate: u64 = 1;
+/// Tries to create a subdomain with a parent that is not allowed to do so.
+const ECreationDisabledForSubDomain: u64 = 2;
+/// Tries to extend the expiration of a subdomain which doesn't have the permission to do so.
+const EExtensionDisabledForSubDomain: u64 = 3;
+/// The subdomain has been replaced by a newer NFT, so it can't be renewed.
+const ESubdomainReplaced: u64 = 4;
+/// Parent for a given subdomain has changed, hence time extension cannot be done.
+const EParentChanged: u64 = 5;
+/// Checks whether a name is allowed or not (against blocked names list)
+const ENotAllowedName: u64 = 6;
+
+/// Enabled metadata value.
+const ACTIVE_METADATA_VALUE: vector<u8> = b"1";
+
+/// The authentication scheme for SuiNS.
+public struct SubDomains has drop {}
+
+/// The key to store the parent's ID in the subdomain object.
+public struct ParentKey has copy, drop, store {}
+
+/// Creates a `leaf` subdomain
+/// A `leaf` subdomain, is a subdomain that is managed by the parent's NFT.
+public fun new_leaf(
+    suins: &mut SuiNS,
+    parent: &SuinsRegistration,
+    clock: &Clock,
+    subdomain_name: String,
+    target: address,
+    ctx: &mut TxContext,
+) {
+    assert!(!denylist::is_blocked_name(suins, subdomain_name), ENotAllowedName);
+
+    let subdomain = domain::new(subdomain_name);
+    // all validation logic for subdomain creation / management.
+    internal_validate_nft_can_manage_subdomain(suins, parent, clock, subdomain, true);
+
+    // Aborts with `suins::registry::ERecordExists` if the subdomain already exists.
+    registry_mut(suins).add_leaf_record(subdomain, clock, target, ctx)
+}
+
+/// Removes a `leaf` subdomain from the registry.
+/// Management of the `leaf` subdomain can only be achieved through the parent's valid NFT.
+public fun remove_leaf(
+    suins: &mut SuiNS,
+    parent: &SuinsRegistration,
+    clock: &Clock,
+    subdomain_name: String,
+) {
+    let subdomain = domain::new(subdomain_name);
+
+    // All validation logic for subdomain creation / management.
+    // We pass `false` as last argument because even if we don't have create capabilities (anymore),
+    // we can still remove a leaf name (we just can't add a new one).
+    internal_validate_nft_can_manage_subdomain(suins, parent, clock, subdomain, false);
+
+    registry_mut(suins).remove_leaf_record(subdomain)
+}
+
+/// Creates a new `node` subdomain
+///
+/// The following script does the following lookups:
+/// 1. Checks if app is authorized.
+/// 2. Validates that the parent NFT is valid and non expired.
+/// 3. Validates that the parent can create subdomains (based on the on-chain setup). [all 2nd level names with valid tld can create names]
+/// 4. Validates the subdomain validity.
+///     2.1 Checks that the TLD is in the list of supported tlds.
+///     2.2 Checks that the length of the new label has the min length.
+///     2.3 Validates that this subdomain can indeed be registered by that parent.
+///     2.4 Validates that the subdomain's expiration timestamp is less or equal to the parents.
+///     2.5 Checks if this subdomain already exists. [If it does, it aborts if it's not expired, overrides otherwise]
+///
+/// It then saves the configuration for that child (manage-able by the parent), and returns the SuinsRegistration object.
+public fun new(
+    suins: &mut SuiNS,
+    parent: &SuinsRegistration,
+    clock: &Clock,
+    subdomain_name: String,
+    expiration_timestamp_ms: u64,
+    allow_creation: bool,
+    allow_time_extension: bool,
+    ctx: &mut TxContext,
+): SubDomainRegistration {
+    assert!(!denylist::is_blocked_name(suins, subdomain_name), ENotAllowedName);
+
+    let subdomain = domain::new(subdomain_name);
+    // all validation logic for subdomain creation / management.
+    internal_validate_nft_can_manage_subdomain(suins, parent, clock, subdomain, true);
+
+    // Validate that the duration is at least the minimum duration.
+    assert!(
+        expiration_timestamp_ms >= clock.timestamp_ms() + app_config(suins).minimum_duration(),
+        EInvalidExpirationDate,
+    );
+    // validate that the requested expiration timestamp is not greater than the parent's one.
+    assert!(expiration_timestamp_ms <= parent.expiration_timestamp_ms(), EInvalidExpirationDate);
+
+    // We register the subdomain (e.g. `subdomain.example.sui`) and return the SuinsRegistration object.
+    // Aborts with `suins::registry::ERecordExists` if the subdomain already exists.
+    let nft = internal_create_subdomain(
+        registry_mut(suins),
+        subdomain,
+        expiration_timestamp_ms,
+        object::id(parent),
+        clock,
+        ctx,
+    );
+
+    // We create the `setup` for the particular SubDomainRegistration.
+    // We save a setting like: `subdomain.example.sui` -> { allow_creation: true/false, allow_time_extension: true/false }
+    if (allow_creation) {
+        internal_set_flag(suins, subdomain, subdomain_allow_creation_key(), allow_creation);
     };
 
-    use subdomains::config::{Self, SubDomainConfig};
-
-    use denylist::denylist;
-
-    /// Tries to create a subdomain that expires later than the parent or below the minimum.
-    const EInvalidExpirationDate: u64 = 1;
-    /// Tries to create a subdomain with a parent that is not allowed to do so.
-    const ECreationDisabledForSubDomain: u64 = 2;
-    /// Tries to extend the expiration of a subdomain which doesn't have the permission to do so.
-    const EExtensionDisabledForSubDomain: u64 = 3;
-    /// The subdomain has been replaced by a newer NFT, so it can't be renewed.
-    const ESubdomainReplaced: u64 = 4;
-    /// Parent for a given subdomain has changed, hence time extension cannot be done.
-    const EParentChanged: u64 = 5;
-    /// Checks whether a name is allowed or not (against blocked names list)
-    const ENotAllowedName: u64 = 6;
-
-    /// Enabled metadata value.
-    const ACTIVE_METADATA_VALUE: vector<u8> = b"1";
-
-    /// The authentication scheme for SuiNS.
-    public struct SubDomains has drop {}
-
-    /// The key to store the parent's ID in the subdomain object.
-    public struct ParentKey has copy, store, drop {}
-
-    /// Creates a `leaf` subdomain
-    /// A `leaf` subdomain, is a subdomain that is managed by the parent's NFT.
-    public fun new_leaf(
-        suins: &mut SuiNS,
-        parent: &SuinsRegistration,
-        clock: &Clock,
-        subdomain_name: String,
-        target: address,
-        ctx: &mut TxContext
-    ) {
-        assert!(!denylist::is_blocked_name(suins, subdomain_name), ENotAllowedName);
-
-        let subdomain = domain::new(subdomain_name);
-        // all validation logic for subdomain creation / management.
-        internal_validate_nft_can_manage_subdomain(suins, parent, clock, subdomain, true);
-
-        // Aborts with `suins::registry::ERecordExists` if the subdomain already exists.
-        registry_mut(suins).add_leaf_record(subdomain, clock, target, ctx)
-    }
-
-    /// Removes a `leaf` subdomain from the registry.
-    /// Management of the `leaf` subdomain can only be achieved through the parent's valid NFT.
-    public fun remove_leaf(
-        suins: &mut SuiNS,
-        parent: &SuinsRegistration,
-        clock: &Clock,
-        subdomain_name: String,
-    ) {
-        let subdomain = domain::new(subdomain_name);
-        
-        // All validation logic for subdomain creation / management.
-        // We pass `false` as last argument because even if we don't have create capabilities (anymore),
-        // we can still remove a leaf name (we just can't add a new one).
-        internal_validate_nft_can_manage_subdomain(suins, parent, clock, subdomain, false);
-
-        registry_mut(suins).remove_leaf_record(subdomain)
-    }
-
-    /// Creates a new `node` subdomain
-    /// 
-    /// The following script does the following lookups:
-    /// 1. Checks if app is authorized.
-    /// 2. Validates that the parent NFT is valid and non expired.
-    /// 3. Validates that the parent can create subdomains (based on the on-chain setup). [all 2nd level names with valid tld can create names]
-    /// 4. Validates the subdomain validity.
-    ///     2.1 Checks that the TLD is in the list of supported tlds.
-    ///     2.2 Checks that the length of the new label has the min length.
-    ///     2.3 Validates that this subdomain can indeed be registered by that parent.
-    ///     2.4 Validates that the subdomain's expiration timestamp is less or equal to the parents.
-    ///     2.5 Checks if this subdomain already exists. [If it does, it aborts if it's not expired, overrides otherwise]
-    /// 
-    /// It then saves the configuration for that child (manage-able by the parent), and returns the SuinsRegistration object.
-    public fun new(
-        suins: &mut SuiNS,
-        parent: &SuinsRegistration,
-        clock: &Clock,
-        subdomain_name: String,
-        expiration_timestamp_ms: u64,
-        allow_creation: bool,
-        allow_time_extension: bool,
-        ctx: &mut TxContext
-    ): SubDomainRegistration {
-        assert!(!denylist::is_blocked_name(suins, subdomain_name), ENotAllowedName);
-
-        let subdomain = domain::new(subdomain_name);
-        // all validation logic for subdomain creation / management.
-        internal_validate_nft_can_manage_subdomain(suins, parent, clock, subdomain, true);
-
-        // Validate that the duration is at least the minimum duration.
-        assert!(expiration_timestamp_ms >= clock.timestamp_ms() + app_config(suins).minimum_duration(), EInvalidExpirationDate);
-        // validate that the requested expiration timestamp is not greater than the parent's one.
-        assert!(expiration_timestamp_ms <= parent.expiration_timestamp_ms(), EInvalidExpirationDate);
-
-        // We register the subdomain (e.g. `subdomain.example.sui`) and return the SuinsRegistration object.
-        // Aborts with `suins::registry::ERecordExists` if the subdomain already exists.
-        let nft = internal_create_subdomain(registry_mut(suins), subdomain, expiration_timestamp_ms, object::id(parent), clock, ctx);
-
-        // We create the `setup` for the particular SubDomainRegistration.
-        // We save a setting like: `subdomain.example.sui` -> { allow_creation: true/false, allow_time_extension: true/false }
-        if (allow_creation) {
-            internal_set_flag(suins, subdomain, subdomain_allow_creation_key(), allow_creation);
-        };
-
-        if (allow_time_extension){
-            internal_set_flag(suins, subdomain, subdomain_allow_extension_key(), allow_time_extension);
-        };
-
-        nft
-    }
-
-    /// Extends the expiration of a `node` subdomain.
-    public fun extend_expiration(
-        suins: &mut SuiNS,
-        sub_nft: &mut SubDomainRegistration,
-        expiration_timestamp_ms: u64,
-    ) {
-        let registry = registry(suins);
-
-        let nft = sub_nft.nft_mut();
-        let subdomain = nft.domain();
-        let parent_domain = subdomain.parent();
-
-        // Check if time extension is allowed for this subdomain.
-        assert!(is_extension_allowed(&record_metadata(suins, subdomain)), EExtensionDisabledForSubDomain);
-
-        let existing_name_record = registry.lookup(subdomain);
-        let parent_name_record = registry.lookup(parent_domain);
-
-        // we need to make sure this name record exists (both child + parent), otherwise we don't have a valid object.
-        assert!(option::is_some(&existing_name_record) && option::is_some(&parent_name_record), ESubdomainReplaced);
-
-        // Validate that the parent of the name is the same as the actual parent
-        // (to prevent cases where owner of the parent changed. When that happens, subdomains lose all abilities to renew / create subdomains)
-        assert!(parent(nft) == option::borrow(&parent_name_record).nft_id(), EParentChanged);
-
-        // validate that expiration date is > than the current.
-        assert!(expiration_timestamp_ms > nft.expiration_timestamp_ms(), EInvalidExpirationDate);
-        // validate that the requested expiration timestamp is not greater than the parent's one.
-        assert!(expiration_timestamp_ms <= option::borrow(&parent_name_record).expiration_timestamp_ms(), EInvalidExpirationDate);
-
-        registry_mut(suins).set_expiration_timestamp_ms(nft, subdomain, expiration_timestamp_ms);
-    }
-
-    /// Called by the parent domain to edit a subdomain's settings.
-    /// - Allows the parent domain to toggle time extension.
-    /// - Allows the parent to toggle subdomain (grand-children) creation
-    /// --> For creations: A parent can't retract already created children, nor can limit the depth if creation capability is on.
-    public fun edit_setup(
-        suins: &mut SuiNS,
-        parent: &SuinsRegistration,
-        clock: &Clock,
-        subdomain_name: String,
-        allow_creation: bool,
-        allow_time_extension: bool
-    ) {
-        // validate that parent is a valid, non expired object.
-        registry(suins).assert_nft_is_authorized(parent, clock);
-
-        let parent_domain = parent.domain();
-        let subdomain = domain::new(subdomain_name);
-
-        // validate that the subdomain is valid for the supplied parent
-        // (as well as it is valid in label length, total length, depth, etc).
-        config::assert_is_valid_subdomain(&parent_domain, &subdomain, app_config(suins));
-
-        // We create the `setup` for the particular SubDomainRegistration.
-        // We save a setting like: `subdomain.example.sui` -> { allow_creation: true/false, allow_time_extension: true/false }
-        internal_set_flag(suins, subdomain, subdomain_allow_creation_key(), allow_creation);
+    if (allow_time_extension) {
         internal_set_flag(suins, subdomain, subdomain_allow_extension_key(), allow_time_extension);
-    }
+    };
 
-    /// Burns a `SubDomainRegistration` object if it is expired.
-    public fun burn(
-        suins: &mut SuiNS,
-        nft: SubDomainRegistration,
-        clock: &Clock,
-    ) {
-        registry_mut(suins).burn_subdomain_object(nft, clock);
-    }
+    nft
+}
 
-    /// Parent ID of a subdomain
-    public fun parent(subdomain: &SuinsRegistration): ID {
-        *df::borrow(subdomain.uid(), ParentKey {})
-    }
+/// Extends the expiration of a `node` subdomain.
+public fun extend_expiration(
+    suins: &mut SuiNS,
+    sub_nft: &mut SubDomainRegistration,
+    expiration_timestamp_ms: u64,
+) {
+    let registry = registry(suins);
 
-    // Sets/removes a (key,value) on the domain's NameRecord metadata (depending on cases).
-    // Validation needs to happen on the calling function.
-    fun internal_set_flag(
-        self: &mut SuiNS,
-        subdomain: Domain,
-        key: String,
-        enable: bool
-    ) {
-        let mut config = record_metadata(self, subdomain);
-        let is_enabled = config.contains(&key);
+    let nft = sub_nft.nft_mut();
+    let subdomain = nft.domain();
+    let parent_domain = subdomain.parent();
 
-        if (enable && !is_enabled) {
-            config.insert(key,  utf8(ACTIVE_METADATA_VALUE));
-        };
+    // Check if time extension is allowed for this subdomain.
+    assert!(
+        is_extension_allowed(&record_metadata(suins, subdomain)),
+        EExtensionDisabledForSubDomain,
+    );
 
-        if(!enable && is_enabled) {
-            config.remove(&key);
-        };
+    let existing_name_record = registry.lookup(subdomain);
+    let parent_name_record = registry.lookup(parent_domain);
 
-        registry_mut(self).set_data(subdomain, config);
-    }
+    // we need to make sure this name record exists (both child + parent), otherwise we don't have a valid object.
+    assert!(
+        option::is_some(&existing_name_record) && option::is_some(&parent_name_record),
+        ESubdomainReplaced,
+    );
 
-    /// Check if subdomain creation is allowed.
-    fun is_creation_allowed(metadata: &VecMap<String, String>): bool {
-        metadata.contains(&subdomain_allow_creation_key())
-    }
+    // Validate that the parent of the name is the same as the actual parent
+    // (to prevent cases where owner of the parent changed. When that happens, subdomains lose all abilities to renew / create subdomains)
+    assert!(parent(nft) == option::borrow(&parent_name_record).nft_id(), EParentChanged);
 
-    /// Check if time extension is allowed.
-    fun is_extension_allowed(metadata: &VecMap<String, String>): bool {
-        metadata.contains(&subdomain_allow_extension_key())
-    }
+    // validate that expiration date is > than the current.
+    assert!(expiration_timestamp_ms > nft.expiration_timestamp_ms(), EInvalidExpirationDate);
+    // validate that the requested expiration timestamp is not greater than the parent's one.
+    assert!(
+        expiration_timestamp_ms <= option::borrow(&parent_name_record).expiration_timestamp_ms(),
+        EInvalidExpirationDate,
+    );
 
-    /// Get the name record's metadata for a subdomain.
-    fun record_metadata(
-        self: &SuiNS,
-        subdomain: Domain
-    ): VecMap<String, String> {
-        *registry(self).get_data(subdomain)
-    }
+    registry_mut(suins).set_expiration_timestamp_ms(nft, subdomain, expiration_timestamp_ms);
+}
 
-    /// Does all the regular checks for validating that a parent `SuinsRegistration` object
-    /// can operate on a given subdomain.
-    /// 
-    /// 1. Checks that NFT is authorized.
-    /// 2. Checks that the parent can create subdomains (applies to subdomain `node` names).
-    /// 3. Validates that the subdomain is valid (accepted TLD, depth, length, is child of given parent, etc).
-    fun internal_validate_nft_can_manage_subdomain(
-        suins: &SuiNS,
-        parent: &SuinsRegistration,
-        clock: &Clock,
-        subdomain: Domain,
-        // Set to `true` for `validate_creation` if you want to validate that the parent can create subdomains.
-        // Set to false when editing the setup of a subdomain or removing leaf names.
-        check_creation_auth: bool
-    ) {
-        // validate that parent is a valid, non expired object.
-        registry(suins).assert_nft_is_authorized(parent, clock);
+/// Called by the parent domain to edit a subdomain's settings.
+/// - Allows the parent domain to toggle time extension.
+/// - Allows the parent to toggle subdomain (grand-children) creation
+/// --> For creations: A parent can't retract already created children, nor can limit the depth if creation capability is on.
+public fun edit_setup(
+    suins: &mut SuiNS,
+    parent: &SuinsRegistration,
+    clock: &Clock,
+    subdomain_name: String,
+    allow_creation: bool,
+    allow_time_extension: bool,
+) {
+    // validate that parent is a valid, non expired object.
+    registry(suins).assert_nft_is_authorized(parent, clock);
 
-        if (check_creation_auth) {
-            // validate that the parent can create subdomains.
-            internal_assert_parent_can_create_subdomains(suins, parent.domain());
-        };
+    let parent_domain = parent.domain();
+    let subdomain = domain::new(subdomain_name);
 
-        // validate that the subdomain is valid for the supplied parent.
-        config::assert_is_valid_subdomain(&parent.domain(), &subdomain, app_config(suins));
-    }
+    // validate that the subdomain is valid for the supplied parent
+    // (as well as it is valid in label length, total length, depth, etc).
+    config::assert_is_valid_subdomain(&parent_domain, &subdomain, app_config(suins));
 
-    /// Validate whether a `SuinsRegistration` object is eligible for creating a subdomain.
-    /// 1. If the NFT is authorized (not expired, active)
-    /// 2. If the parent is a subdomain, check whether it is allowed to create subdomains.
-    fun internal_assert_parent_can_create_subdomains(
-        self: &SuiNS,
-        parent: Domain,
-    ) {
-        // if the parent is not a subdomain, we can always create subdomains.
-        if (!is_subdomain(&parent)) {
-            return
-        };
+    // We create the `setup` for the particular SubDomainRegistration.
+    // We save a setting like: `subdomain.example.sui` -> { allow_creation: true/false, allow_time_extension: true/false }
+    internal_set_flag(suins, subdomain, subdomain_allow_creation_key(), allow_creation);
+    internal_set_flag(suins, subdomain, subdomain_allow_extension_key(), allow_time_extension);
+}
 
-        // if `parent` is a subdomain. We check the subdomain config to see if we are allowed to mint subdomains.
-        // For regular names (e.g. example.sui), we can always mint subdomains.
-        // if there's no config for this parent, and the parent is a subdomain, we can't create deeper names.
-        assert!(is_creation_allowed(&record_metadata(self, parent)), ECreationDisabledForSubDomain);
-    }
+/// Burns a `SubDomainRegistration` object if it is expired.
+public fun burn(suins: &mut SuiNS, nft: SubDomainRegistration, clock: &Clock) {
+    registry_mut(suins).burn_subdomain_object(nft, clock);
+}
 
+/// Parent ID of a subdomain
+public fun parent(subdomain: &SuinsRegistration): ID {
+    *df::borrow(subdomain.uid(), ParentKey {})
+}
 
-    /// An internal function to add a subdomain to the registry with the correct expiration timestamp. 
-    /// It doesn't check whether the expiration is valid. This needs to be checked on the calling function.
-    fun internal_create_subdomain(
-        registry: &mut Registry,
-        subdomain: Domain,
-        expiration_timestamp_ms: u64,
-        parent_nft_id: ID,
-        clock: &Clock,
-        ctx: &mut TxContext,
-    ): SubDomainRegistration {
-        let mut nft = registry.add_record_ignoring_grace_period(subdomain, 1, clock, ctx);
-        // set the timestamp to the correct one. `add_record` only works with years but we can correct it easily here.
-        registry.set_expiration_timestamp_ms(&mut nft, subdomain, expiration_timestamp_ms);
+// Sets/removes a (key,value) on the domain's NameRecord metadata (depending on cases).
+// Validation needs to happen on the calling function.
+fun internal_set_flag(self: &mut SuiNS, subdomain: Domain, key: String, enable: bool) {
+    let mut config = record_metadata(self, subdomain);
+    let is_enabled = config.contains(&key);
 
-        // attach the `ParentID` to the SuinsRegistration, so we validate that the parent who created this subdomain
-        // is the same as the one currently holding the parent domain.
-        df::add(nft.uid_mut(), ParentKey {}, parent_nft_id);
+    if (enable && !is_enabled) {
+        config.insert(key, utf8(ACTIVE_METADATA_VALUE));
+    };
 
-        registry.wrap_subdomain(nft, clock, ctx)
-    }
+    if (!enable && is_enabled) {
+        config.remove(&key);
+    };
 
-    // == Internal helper to access registry & app setup ==
+    registry_mut(self).set_data(subdomain, config);
+}
 
-    fun registry(suins: &SuiNS): &Registry {
-        suins.registry<Registry>()
-    }
+/// Check if subdomain creation is allowed.
+fun is_creation_allowed(metadata: &VecMap<String, String>): bool {
+    metadata.contains(&subdomain_allow_creation_key())
+}
 
-    fun registry_mut(suins: &mut SuiNS): &mut Registry {
-        suins::app_registry_mut<SubDomains, Registry>(SubDomains {}, suins)
-    }
+/// Check if time extension is allowed.
+fun is_extension_allowed(metadata: &VecMap<String, String>): bool {
+    metadata.contains(&subdomain_allow_extension_key())
+}
 
-    fun app_config(suins: &SuiNS): &SubDomainConfig {
-        suins.get_config<SubDomainConfig>()
-    }
+/// Get the name record's metadata for a subdomain.
+fun record_metadata(self: &SuiNS, subdomain: Domain): VecMap<String, String> {
+    *registry(self).get_data(subdomain)
+}
 
-    #[test_only]
-    public fun auth_for_testing(): SubDomains {
-        SubDomains {}
-    }
+/// Does all the regular checks for validating that a parent `SuinsRegistration` object
+/// can operate on a given subdomain.
+///
+/// 1. Checks that NFT is authorized.
+/// 2. Checks that the parent can create subdomains (applies to subdomain `node` names).
+/// 3. Validates that the subdomain is valid (accepted TLD, depth, length, is child of given parent, etc).
+fun internal_validate_nft_can_manage_subdomain(
+    suins: &SuiNS,
+    parent: &SuinsRegistration,
+    clock: &Clock,
+    subdomain: Domain,
+    // Set to `true` for `validate_creation` if you want to validate that the parent can create subdomains.
+    // Set to false when editing the setup of a subdomain or removing leaf names.
+    check_creation_auth: bool,
+) {
+    // validate that parent is a valid, non expired object.
+    registry(suins).assert_nft_is_authorized(parent, clock);
+
+    if (check_creation_auth) {
+        // validate that the parent can create subdomains.
+        internal_assert_parent_can_create_subdomains(suins, parent.domain());
+    };
+
+    // validate that the subdomain is valid for the supplied parent.
+    config::assert_is_valid_subdomain(&parent.domain(), &subdomain, app_config(suins));
+}
+
+/// Validate whether a `SuinsRegistration` object is eligible for creating a subdomain.
+/// 1. If the NFT is authorized (not expired, active)
+/// 2. If the parent is a subdomain, check whether it is allowed to create subdomains.
+fun internal_assert_parent_can_create_subdomains(self: &SuiNS, parent: Domain) {
+    // if the parent is not a subdomain, we can always create subdomains.
+    if (!is_subdomain(&parent)) {
+        return
+    };
+
+    // if `parent` is a subdomain. We check the subdomain config to see if we are allowed to mint subdomains.
+    // For regular names (e.g. example.sui), we can always mint subdomains.
+    // if there's no config for this parent, and the parent is a subdomain, we can't create deeper names.
+    assert!(is_creation_allowed(&record_metadata(self, parent)), ECreationDisabledForSubDomain);
+}
+
+/// An internal function to add a subdomain to the registry with the correct expiration timestamp.
+/// It doesn't check whether the expiration is valid. This needs to be checked on the calling function.
+fun internal_create_subdomain(
+    registry: &mut Registry,
+    subdomain: Domain,
+    expiration_timestamp_ms: u64,
+    parent_nft_id: ID,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): SubDomainRegistration {
+    let mut nft = registry.add_record_ignoring_grace_period(subdomain, 1, clock, ctx);
+    // set the timestamp to the correct one. `add_record` only works with years but we can correct it easily here.
+    registry.set_expiration_timestamp_ms(&mut nft, subdomain, expiration_timestamp_ms);
+
+    // attach the `ParentID` to the SuinsRegistration, so we validate that the parent who created this subdomain
+    // is the same as the one currently holding the parent domain.
+    df::add(nft.uid_mut(), ParentKey {}, parent_nft_id);
+
+    registry.wrap_subdomain(nft, clock, ctx)
+}
+
+// == Internal helper to access registry & app setup ==
+
+fun registry(suins: &SuiNS): &Registry {
+    suins.registry<Registry>()
+}
+
+fun registry_mut(suins: &mut SuiNS): &mut Registry {
+    suins::app_registry_mut<SubDomains, Registry>(SubDomains {}, suins)
+}
+
+fun app_config(suins: &SuiNS): &SubDomainConfig {
+    suins.get_config<SubDomainConfig>()
+}
+
+#[test_only]
+public fun auth_for_testing(): SubDomains {
+    SubDomains {}
 }

--- a/packages/subdomains/tests/subdomain_tests.move
+++ b/packages/subdomains/tests/subdomain_tests.move
@@ -2,305 +2,408 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-module subdomains::subdomain_tests {
-    use std::string::{String, utf8};
+module subdomains::subdomain_tests;
 
-    use sui::{test_scenario::{Self as ts, Scenario, ctx}, clock::{Self, Clock}};
+use denylist::denylist;
+use std::string::{String, utf8};
+use subdomains::{config, subdomains::{Self, SubDomains}};
+use sui::{clock::{Self, Clock}, test_scenario::{Self as ts, Scenario, ctx}};
+use suins::{
+    constants::{grace_period_ms, year_ms},
+    domain,
+    registry::{Self, Registry},
+    registry_tests::burn_nfts,
+    subdomain_registration::{Self, SubDomainRegistration},
+    suins::{Self, SuiNS, AdminCap},
+    suins_registration::{Self, SuinsRegistration}
+};
 
-    use suins::{
-        domain, 
-        constants::{grace_period_ms, year_ms}, 
-        suins::{Self, SuiNS, AdminCap}, 
-        registry::{Self, Registry}, 
-        suins_registration::{Self, SuinsRegistration}, 
-        subdomain_registration::{Self, SubDomainRegistration}, 
-        registry_tests::{burn_nfts}
+const USER_ADDRESS: address = @0x01;
+const TEST_ADDRESS: address = @0x02;
+
+const MIN_SUBDOMAIN_DURATION: u64 = 24 * 60 * 60 * 1000; // 1 day
+
+#[test]
+/// A test scenario
+fun test_multiple_operation_cases() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    let mut child = create_node_subdomain(
+        &parent,
+        utf8(b"node.test.sui"),
+        MIN_SUBDOMAIN_DURATION,
+        true,
+        true,
+        scenario,
+    );
+
+    create_leaf_subdomain(&parent, utf8(b"leaf.test.sui"), TEST_ADDRESS, scenario);
+    remove_leaf_subdomain(&parent, utf8(b"leaf.test.sui"), scenario);
+
+    // Create a node name with the same name as the leaf that was deleted.
+    let another_child = create_node_subdomain(
+        &parent,
+        utf8(b"leaf.test.sui"),
+        MIN_SUBDOMAIN_DURATION,
+        true,
+        true,
+        scenario,
+    );
+
+    let nested = create_node_subdomain(
+        subdomain_registration::nft(&child),
+        utf8(b"nested.node.test.sui"),
+        MIN_SUBDOMAIN_DURATION,
+        true,
+        true,
+        scenario,
+    );
+
+    // extend node's subdomain expiration to the limit.
+    extend_node_subdomain(
+        &mut child,
+        suins_registration::expiration_timestamp_ms(&parent),
+        scenario,
+    );
+
+    // update subdomain's setup for testing
+    update_subdomain_setup(&parent, utf8(b"node.test.sui"), false, false, scenario);
+
+    increment_clock(year_ms() +1, scenario);
+
+    burn_subdomain(child, scenario);
+    burn_subdomain(nested, scenario);
+    burn_subdomain(another_child, scenario);
+
+    burn_nfts(vector[parent]);
+    ts::end(scenario_val);
+}
+
+#[test, expected_failure(abort_code = ::subdomains::subdomains::EInvalidExpirationDate)]
+fun expiration_past_parents_expiration() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    let _child = create_node_subdomain(
+        &parent,
+        utf8(b"node.test.sui"),
+        suins_registration::expiration_timestamp_ms(&parent) + 1,
+        true,
+        true,
+        scenario,
+    );
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::subdomains::config::EInvalidParent)]
+/// tries to create a child node using an invalid parent.
+fun invalid_parent_failure() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    let _child = create_node_subdomain(
+        &parent,
+        utf8(b"node.example.sui"),
+        suins_registration::expiration_timestamp_ms(&parent),
+        true,
+        true,
+        scenario,
+    );
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::subdomains::subdomains::ECreationDisabledForSubDomain)]
+fun tries_to_create_subdomain_with_disallowed_node_parent() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    let child = create_node_subdomain(
+        &parent,
+        utf8(b"node.test.sui"),
+        suins_registration::expiration_timestamp_ms(&parent),
+        false,
+        true,
+        scenario,
+    );
+
+    let child_nft = subdomain_registration::nft(&child);
+    let _nested = create_node_subdomain(
+        child_nft,
+        utf8(b"test.node.test.sui"),
+        suins_registration::expiration_timestamp_ms(child_nft),
+        false,
+        true,
+        scenario,
+    );
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::subdomains::subdomains::EExtensionDisabledForSubDomain)]
+fun tries_to_extend_without_permissions() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    let mut child = create_node_subdomain(
+        &parent,
+        utf8(b"node.test.sui"),
+        MIN_SUBDOMAIN_DURATION,
+        false,
+        false,
+        scenario,
+    );
+
+    extend_node_subdomain(&mut child, 2, scenario);
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::subdomains::subdomains::EParentChanged)]
+fun tries_to_extend_while_parent_changed() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    // child is an expired name ofc.
+    let mut child = create_node_subdomain(
+        &parent,
+        utf8(b"node.test.sui"),
+        MIN_SUBDOMAIN_DURATION,
+        true,
+        true,
+        scenario,
+    );
+
+    increment_clock(
+        suins_registration::expiration_timestamp_ms(&parent) +grace_period_ms() + 1,
+        scenario,
+    );
+
+    let _parent_w_different_owner = create_sld_name(utf8(b"test.sui"), scenario);
+
+    // any extension.
+    extend_node_subdomain(&mut child, 2, scenario);
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::suins::registry::ERecordExpired)]
+fun tries_to_use_expired_subdomain_to_create_new() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    let child = create_node_subdomain(
+        &parent,
+        utf8(b"node.test.sui"),
+        MIN_SUBDOMAIN_DURATION,
+        true,
+        true,
+        scenario,
+    );
+
+    increment_clock(MIN_SUBDOMAIN_DURATION +1, scenario);
+    create_leaf_subdomain(
+        subdomain_registration::nft(&child),
+        utf8(b"node.node.test.sui"),
+        TEST_ADDRESS,
+        scenario,
+    );
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::subdomains::subdomains::EInvalidExpirationDate)]
+fun tries_to_create_too_short_subdomain() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+
+    let _child = create_node_subdomain(&parent, utf8(b"node.test.sui"), 1, true, true, scenario);
+
+    abort 1337
+}
+
+#[test, expected_failure(abort_code = ::subdomains::config::EInvalidParent)]
+fun tries_to_created_nested_leaf_subdomain() {
+    let mut scenario_val = test_init();
+    let scenario = &mut scenario_val;
+    let parent = create_sld_name(utf8(b"test.sui"), scenario);
+    create_leaf_subdomain(&parent, utf8(b"node.node.test.sui"), TEST_ADDRESS, scenario);
+
+    abort 1337
+}
+
+// == Helpers ==
+
+public fun test_init(): Scenario {
+    let mut scenario_val = ts::begin(USER_ADDRESS);
+    let scenario = &mut scenario_val;
+    {
+        let mut suins = suins::init_for_testing(ctx(scenario));
+        suins::authorize_app_for_testing<SubDomains>(&mut suins);
+        suins::share_for_testing(suins);
+        let clock = clock::create_for_testing(ctx(scenario));
+        clock::share_for_testing(clock);
     };
-    
-    use denylist::denylist;
+    {
+        ts::next_tx(scenario, USER_ADDRESS);
+        let admin_cap = ts::take_from_sender<AdminCap>(scenario);
+        let mut suins = ts::take_shared<SuiNS>(scenario);
+        suins::add_config(&admin_cap, &mut suins, config::default());
 
-    use subdomains::{
-        config,
-        subdomains::{Self, SubDomains}
+        registry::init_for_testing(&admin_cap, &mut suins, ctx(scenario));
+        denylist::setup(&mut suins, &admin_cap, ctx(scenario));
+
+        ts::return_shared(suins);
+        ts::return_to_sender(scenario, admin_cap);
     };
-
-    const USER_ADDRESS: address = @0x01;
-    const TEST_ADDRESS: address = @0x02;
-
-    const MIN_SUBDOMAIN_DURATION: u64 = 24 * 60 * 60 * 1000; // 1 day
-
-
-    #[test]
-    /// A test scenario
-    fun test_multiple_operation_cases() {
-
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        let mut child = create_node_subdomain(&parent, utf8(b"node.test.sui"), MIN_SUBDOMAIN_DURATION, true, true, scenario);
-
-        create_leaf_subdomain(&parent, utf8(b"leaf.test.sui"), TEST_ADDRESS, scenario);
-        remove_leaf_subdomain(&parent, utf8(b"leaf.test.sui"), scenario);
-
-        // Create a node name with the same name as the leaf that was deleted.
-        let another_child = create_node_subdomain(&parent, utf8(b"leaf.test.sui"), MIN_SUBDOMAIN_DURATION, true, true, scenario);
-
-        let nested = create_node_subdomain(subdomain_registration::nft(&child), utf8(b"nested.node.test.sui"), MIN_SUBDOMAIN_DURATION, true, true, scenario);
-
-        // extend node's subdomain expiration to the limit.
-        extend_node_subdomain(&mut child, suins_registration::expiration_timestamp_ms(&parent), scenario);
-
-        // update subdomain's setup for testing
-        update_subdomain_setup(&parent, utf8(b"node.test.sui"), false, false, scenario);
-
-        increment_clock(year_ms() +1, scenario);
-
-        burn_subdomain(child, scenario);
-        burn_subdomain(nested, scenario);
-        burn_subdomain(another_child, scenario);
-
-        burn_nfts(vector[parent]);
-        ts::end(scenario_val);
-    }
-
-    #[test, expected_failure(abort_code=::subdomains::subdomains::EInvalidExpirationDate)]
-    fun expiration_past_parents_expiration() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        let _child = create_node_subdomain(&parent, utf8(b"node.test.sui"), suins_registration::expiration_timestamp_ms(&parent) + 1, true, true, scenario);
-
-        abort 1337
-    }
-
-    #[test, expected_failure(abort_code=::subdomains::config::EInvalidParent)]
-    /// tries to create a child node using an invalid parent.
-    fun invalid_parent_failure(){
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        let _child = create_node_subdomain(&parent, utf8(b"node.example.sui"), suins_registration::expiration_timestamp_ms(&parent), true, true, scenario);
-
-        abort 1337  
-    }
-
-
-    #[test, expected_failure(abort_code=::subdomains::subdomains::ECreationDisabledForSubDomain)]
-    fun tries_to_create_subdomain_with_disallowed_node_parent() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        let child = create_node_subdomain(&parent, utf8(b"node.test.sui"), suins_registration::expiration_timestamp_ms(&parent), false, true, scenario);
-
-        let child_nft = subdomain_registration::nft(&child);
-        let _nested = create_node_subdomain(child_nft, utf8(b"test.node.test.sui"), suins_registration::expiration_timestamp_ms(child_nft), false, true, scenario);
-
-        abort 1337  
-    }
-
-    #[test, expected_failure(abort_code=::subdomains::subdomains::EExtensionDisabledForSubDomain)]
-    fun tries_to_extend_without_permissions() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        let mut child = create_node_subdomain(&parent, utf8(b"node.test.sui"), MIN_SUBDOMAIN_DURATION, false, false, scenario);
-
-        extend_node_subdomain(&mut child, 2, scenario);
-
-        abort 1337  
-    }
-
-    #[test, expected_failure(abort_code=::subdomains::subdomains::EParentChanged)]
-    fun tries_to_extend_while_parent_changed() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        // child is an expired name ofc.
-        let mut child = create_node_subdomain(&parent, utf8(b"node.test.sui"), MIN_SUBDOMAIN_DURATION, true, true, scenario);
-
-        increment_clock(suins_registration::expiration_timestamp_ms(&parent) +grace_period_ms() + 1 , scenario);
-
-        let _parent_w_different_owner = create_sld_name(utf8(b"test.sui"), scenario);
-
-        // any extension.
-        extend_node_subdomain(&mut child, 2, scenario);
-
-        abort 1337  
-    }
-    
-    #[test, expected_failure(abort_code=::suins::registry::ERecordExpired)]
-    fun tries_to_use_expired_subdomain_to_create_new() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        let child = create_node_subdomain(&parent, utf8(b"node.test.sui"), MIN_SUBDOMAIN_DURATION, true, true, scenario);
-
-        increment_clock(MIN_SUBDOMAIN_DURATION +1, scenario);
-        create_leaf_subdomain(subdomain_registration::nft(&child), utf8(b"node.node.test.sui"), TEST_ADDRESS, scenario);
-
-        abort 1337  
-    }
-
-    #[test, expected_failure(abort_code=::subdomains::subdomains::EInvalidExpirationDate)]
-    fun tries_to_create_too_short_subdomain() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-
-        let _child = create_node_subdomain(&parent, utf8(b"node.test.sui"), 1, true, true, scenario);
-
-        abort 1337  
-    }
-
-    #[test, expected_failure(abort_code=::subdomains::config::EInvalidParent)]
-    fun tries_to_created_nested_leaf_subdomain() {
-        let mut scenario_val = test_init();
-        let scenario = &mut scenario_val;
-        let parent = create_sld_name(utf8(b"test.sui"), scenario);
-        create_leaf_subdomain(&parent, utf8(b"node.node.test.sui"), TEST_ADDRESS, scenario);
-
-        abort 1337  
-    }
-
-
-
-    // == Helpers == 
-
-    public fun test_init(): Scenario {
-        let mut scenario_val = ts::begin(USER_ADDRESS);
-        let scenario = &mut scenario_val;
-        {
-            let mut suins = suins::init_for_testing(ctx(scenario));
-            suins::authorize_app_for_testing<SubDomains>(&mut suins);
-            suins::share_for_testing(suins);
-            let clock = clock::create_for_testing(ctx(scenario));
-            clock::share_for_testing(clock);
-        };
-        {
-            ts::next_tx(scenario, USER_ADDRESS);
-            let admin_cap = ts::take_from_sender<AdminCap>(scenario);
-            let mut suins = ts::take_shared<SuiNS>(scenario);
-            suins::add_config(&admin_cap, &mut suins, config::default());
-
-            registry::init_for_testing(&admin_cap, &mut suins, ctx(scenario));
-            denylist::setup(&mut suins, &admin_cap, ctx(scenario));
-
-            ts::return_shared(suins);
-            ts::return_to_sender(scenario, admin_cap);
-        };
-        scenario_val
-    }
-
-    /// Get the active registry of the current scenario. (mutable, so we can add extra names ourselves)
-    public fun registry_mut(suins: &mut SuiNS): &mut Registry {
-
-        let registry_mut = suins::app_registry_mut<SubDomains, Registry>(subdomains::auth_for_testing(), suins);
-
-        registry_mut
-    }
-    
-    /// Create a regular name to help with our tests.
-    public fun create_sld_name(name: String, scenario: &mut Scenario): SuinsRegistration {
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut suins = ts::take_shared<SuiNS>(scenario);
-        let clock = ts::take_shared<Clock>(scenario);
-        let registry_mut = registry_mut(&mut suins);
-
-        let parent = registry::add_record(registry_mut, domain::new(name), 1, &clock, ctx(scenario));
-
-        ts::return_shared(clock);
-        ts::return_shared(suins);
-        parent
-    } 
-
-    /// Create a leaf subdomain
-    public fun create_leaf_subdomain(parent: &SuinsRegistration, name: String, target: address, scenario: &mut Scenario) {
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut suins = ts::take_shared<SuiNS>(scenario);
-        let clock = ts::take_shared<Clock>(scenario);
-
-        subdomains::new_leaf(&mut suins, parent, &clock, name, target, ctx(scenario));
-
-        ts::return_shared(suins);
-        ts::return_shared(clock);
-    }
-
-    /// Remove a leaf subdomain
-    public fun remove_leaf_subdomain(parent: &SuinsRegistration, name: String, scenario: &mut Scenario) {
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut suins = ts::take_shared<SuiNS>(scenario);
-        let clock = ts::take_shared<Clock>(scenario);
-        
-        subdomains::remove_leaf(&mut suins, parent, &clock, name);
-
-        ts::return_shared(suins);
-        ts::return_shared(clock);
-    }
-
-    /// Create a node subdomain
-    public fun create_node_subdomain(parent: &SuinsRegistration, name: String, expiration: u64, allow_creation: bool, allow_extension: bool, scenario: &mut Scenario): SubDomainRegistration {
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut suins = ts::take_shared<SuiNS>(scenario);
-        let clock = ts::take_shared<Clock>(scenario);
-
-        let nft = subdomains::new(&mut suins, parent, &clock, name, expiration, allow_creation, allow_extension, ctx(scenario));
-
-        ts::return_shared(suins);
-        ts::return_shared(clock);
-
-        nft
-    }
-
-    /// Extend a node subdomain's expiration.
-    public fun extend_node_subdomain(nft: &mut SubDomainRegistration, expiration: u64, scenario: &mut Scenario) {
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut suins = ts::take_shared<SuiNS>(scenario);
-        let clock = ts::take_shared<Clock>(scenario);
-
-        subdomains::extend_expiration(&mut suins, nft, expiration);
-
-        ts::return_shared(suins);
-        ts::return_shared(clock);
-    }
-
-    public fun update_subdomain_setup(parent: &SuinsRegistration, subdomain: String, allow_creation: bool, allow_extension: bool, scenario: &mut Scenario) {
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut suins = ts::take_shared<SuiNS>(scenario);
-        let clock = ts::take_shared<Clock>(scenario);
-
-
-        subdomains::edit_setup(&mut suins, parent, &clock, subdomain, allow_creation, allow_extension);
-
-
-        ts::return_shared(suins);
-        ts::return_shared(clock);
-    } 
-
-    public fun burn_subdomain(nft: SubDomainRegistration, scenario: &mut Scenario) {
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut suins = ts::take_shared<SuiNS>(scenario);
-        let clock = ts::take_shared<Clock>(scenario);
-
-        subdomains::burn(&mut suins, nft, &clock);
-
-        ts::return_shared(suins);
-        ts::return_shared(clock);
-    } 
-
-
-    public fun increment_clock(to: u64, scenario: &mut Scenario){
-        ts::next_tx(scenario, USER_ADDRESS);
-        let mut clock = ts::take_shared<Clock>(scenario);
-        clock::increment_for_testing(&mut clock, to);
-        ts::return_shared(clock);
-    }
-
+    scenario_val
+}
+
+/// Get the active registry of the current scenario. (mutable, so we can add extra names ourselves)
+public fun registry_mut(suins: &mut SuiNS): &mut Registry {
+    let registry_mut = suins::app_registry_mut<SubDomains, Registry>(
+        subdomains::auth_for_testing(),
+        suins,
+    );
+
+    registry_mut
+}
+
+/// Create a regular name to help with our tests.
+public fun create_sld_name(name: String, scenario: &mut Scenario): SuinsRegistration {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut suins = ts::take_shared<SuiNS>(scenario);
+    let clock = ts::take_shared<Clock>(scenario);
+    let registry_mut = registry_mut(&mut suins);
+
+    let parent = registry::add_record(registry_mut, domain::new(name), 1, &clock, ctx(scenario));
+
+    ts::return_shared(clock);
+    ts::return_shared(suins);
+    parent
+}
+
+/// Create a leaf subdomain
+public fun create_leaf_subdomain(
+    parent: &SuinsRegistration,
+    name: String,
+    target: address,
+    scenario: &mut Scenario,
+) {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut suins = ts::take_shared<SuiNS>(scenario);
+    let clock = ts::take_shared<Clock>(scenario);
+
+    subdomains::new_leaf(&mut suins, parent, &clock, name, target, ctx(scenario));
+
+    ts::return_shared(suins);
+    ts::return_shared(clock);
+}
+
+/// Remove a leaf subdomain
+public fun remove_leaf_subdomain(
+    parent: &SuinsRegistration,
+    name: String,
+    scenario: &mut Scenario,
+) {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut suins = ts::take_shared<SuiNS>(scenario);
+    let clock = ts::take_shared<Clock>(scenario);
+
+    subdomains::remove_leaf(&mut suins, parent, &clock, name);
+
+    ts::return_shared(suins);
+    ts::return_shared(clock);
+}
+
+/// Create a node subdomain
+public fun create_node_subdomain(
+    parent: &SuinsRegistration,
+    name: String,
+    expiration: u64,
+    allow_creation: bool,
+    allow_extension: bool,
+    scenario: &mut Scenario,
+): SubDomainRegistration {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut suins = ts::take_shared<SuiNS>(scenario);
+    let clock = ts::take_shared<Clock>(scenario);
+
+    let nft = subdomains::new(
+        &mut suins,
+        parent,
+        &clock,
+        name,
+        expiration,
+        allow_creation,
+        allow_extension,
+        ctx(scenario),
+    );
+
+    ts::return_shared(suins);
+    ts::return_shared(clock);
+
+    nft
+}
+
+/// Extend a node subdomain's expiration.
+public fun extend_node_subdomain(
+    nft: &mut SubDomainRegistration,
+    expiration: u64,
+    scenario: &mut Scenario,
+) {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut suins = ts::take_shared<SuiNS>(scenario);
+    let clock = ts::take_shared<Clock>(scenario);
+
+    subdomains::extend_expiration(&mut suins, nft, expiration);
+
+    ts::return_shared(suins);
+    ts::return_shared(clock);
+}
+
+public fun update_subdomain_setup(
+    parent: &SuinsRegistration,
+    subdomain: String,
+    allow_creation: bool,
+    allow_extension: bool,
+    scenario: &mut Scenario,
+) {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut suins = ts::take_shared<SuiNS>(scenario);
+    let clock = ts::take_shared<Clock>(scenario);
+
+    subdomains::edit_setup(&mut suins, parent, &clock, subdomain, allow_creation, allow_extension);
+
+    ts::return_shared(suins);
+    ts::return_shared(clock);
+}
+
+public fun burn_subdomain(nft: SubDomainRegistration, scenario: &mut Scenario) {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut suins = ts::take_shared<SuiNS>(scenario);
+    let clock = ts::take_shared<Clock>(scenario);
+
+    subdomains::burn(&mut suins, nft, &clock);
+
+    ts::return_shared(suins);
+    ts::return_shared(clock);
+}
+
+public fun increment_clock(to: u64, scenario: &mut Scenario) {
+    ts::next_tx(scenario, USER_ADDRESS);
+    let mut clock = ts::take_shared<Clock>(scenario);
+    clock::increment_for_testing(&mut clock, to);
+    ts::return_shared(clock);
 }

--- a/packages/subdomains/tests/unit_tests.move
+++ b/packages/subdomains/tests/unit_tests.move
@@ -2,66 +2,113 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]
-module subdomains::unit_tests {
-    use std::string::{utf8};
-    use suins::domain::{Self, new as new_domain, parent};
-    use subdomains::config::{assert_is_valid_subdomain, default};
+module subdomains::unit_tests;
 
-    // === Validity of subdomain | parent lengths (based on string) ===
-    #[test]
-    fun test_parent_relationships() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"example.sui")), &new_domain(utf8(b"sub.example.sui")), &default());
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.example.sui")), &new_domain(utf8(b"sub.sub.example.sui")), &default());
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.sub.example.sui")), &new_domain(utf8(b"sub.sub.sub.example.sui")), &default());
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.sub.sub.sub.sub.example.sui")), &new_domain(utf8(b"sub.sub.sub.sub.sub.sub.example.sui")), &default());
-    }
+use std::string::utf8;
+use subdomains::config::{assert_is_valid_subdomain, default};
+use suins::domain::{Self, new as new_domain, parent};
 
-    #[test, expected_failure(abort_code=subdomains::config::EDepthOutOfLimit)]
-    fun test_too_large_subdomain_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"example.sui")), &new_domain(utf8(b"sub.sub.sub.sub.sub.sub.sub.sub.sub.example.sui")), &default());
-    }
+// === Validity of subdomain | parent lengths (based on string) ===
+#[test]
+fun test_parent_relationships() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"example.sui")),
+        &new_domain(utf8(b"sub.example.sui")),
+        &default(),
+    );
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.example.sui")),
+        &new_domain(utf8(b"sub.sub.example.sui")),
+        &default(),
+    );
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.sub.example.sui")),
+        &new_domain(utf8(b"sub.sub.sub.example.sui")),
+        &default(),
+    );
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.sub.sub.sub.sub.example.sui")),
+        &new_domain(utf8(b"sub.sub.sub.sub.sub.sub.example.sui")),
+        &default(),
+    );
+}
 
-    #[test, expected_failure(abort_code=subdomains::config::EInvalidParent)]
-    fun test_invalid_parent_length_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"example.sui")), &new_domain(utf8(b"sub.sub.example.sui")), &default());
-    }
+#[test, expected_failure(abort_code = subdomains::config::EDepthOutOfLimit)]
+fun test_too_large_subdomain_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"example.sui")),
+        &new_domain(utf8(b"sub.sub.sub.sub.sub.sub.sub.sub.sub.example.sui")),
+        &default(),
+    );
+}
 
-    #[test, expected_failure(abort_code=subdomains::config::EInvalidParent)]
-    fun test_invalid_parent_smaller_length_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.sub.example.sui")), &new_domain(utf8(b"sub.example.sui")), &default());
-    }
+#[test, expected_failure(abort_code = subdomains::config::EInvalidParent)]
+fun test_invalid_parent_length_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"example.sui")),
+        &new_domain(utf8(b"sub.sub.example.sui")),
+        &default(),
+    );
+}
 
-    #[test, expected_failure(abort_code=subdomains::config::EInvalidParent)]
-    fun test_invalid_parent_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"test.example.sui")), &new_domain(utf8(b"sub.sub.example.sui")), &default());
-    }
+#[test, expected_failure(abort_code = subdomains::config::EInvalidParent)]
+fun test_invalid_parent_smaller_length_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.sub.example.sui")),
+        &new_domain(utf8(b"sub.example.sui")),
+        &default(),
+    );
+}
 
-    #[test, expected_failure(abort_code=subdomains::config::EInvalidParent)]
-    fun test_invalid_parent_tld_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.example.move")), &new_domain(utf8(b"sub.sub.example.sui")), &default());
-    }
-    #[test, expected_failure(abort_code=subdomains::config::EInvalidParent)]
-    fun test_invalid_parent_sld_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.exampl.sui")), &new_domain(utf8(b"sub.sub.example.sui")), &default());
-    }
-    
-    #[test, expected_failure(abort_code=subdomains::config::EInvalidLabelSize)]
-    fun test_invalid_child_label_size_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.exampl.sui")), &new_domain(utf8(b"ob.example.sui")), &default());
-    }
+#[test, expected_failure(abort_code = subdomains::config::EInvalidParent)]
+fun test_invalid_parent_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"test.example.sui")),
+        &new_domain(utf8(b"sub.sub.example.sui")),
+        &default(),
+    );
+}
 
-    #[test, expected_failure(abort_code=subdomains::config::ENotSupportedTLD)]
-    fun test_not_supported_tld_failure() {
-        assert_is_valid_subdomain(&new_domain(utf8(b"sub.sub.example.move")), &new_domain(utf8(b"sub.example.move")), &default());
-    }
+#[test, expected_failure(abort_code = subdomains::config::EInvalidParent)]
+fun test_invalid_parent_tld_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.example.move")),
+        &new_domain(utf8(b"sub.sub.example.sui")),
+        &default(),
+    );
+}
+#[test, expected_failure(abort_code = subdomains::config::EInvalidParent)]
+fun test_invalid_parent_sld_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.exampl.sui")),
+        &new_domain(utf8(b"sub.sub.example.sui")),
+        &default(),
+    );
+}
 
-    #[test]
-    fun derive_parent_from_child(){
-        let parent = parent(&new_domain(utf8(b"sub.example.sui")));
-        assert!(domain::to_string(&parent) == utf8(b"example.sui"), 0);
+#[test, expected_failure(abort_code = subdomains::config::EInvalidLabelSize)]
+fun test_invalid_child_label_size_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.exampl.sui")),
+        &new_domain(utf8(b"ob.example.sui")),
+        &default(),
+    );
+}
 
-        let parent = parent(&new_domain(utf8(b"sub.sub.sub.sub.sub.sub.example.sui")));
-        assert!(domain::to_string(&parent) == utf8(b"sub.sub.sub.sub.sub.example.sui"), 0);
+#[test, expected_failure(abort_code = subdomains::config::ENotSupportedTLD)]
+fun test_not_supported_tld_failure() {
+    assert_is_valid_subdomain(
+        &new_domain(utf8(b"sub.sub.example.move")),
+        &new_domain(utf8(b"sub.example.move")),
+        &default(),
+    );
+}
 
-    }
+#[test]
+fun derive_parent_from_child() {
+    let parent = parent(&new_domain(utf8(b"sub.example.sui")));
+    assert!(domain::to_string(&parent) == utf8(b"example.sui"), 0);
+
+    let parent = parent(&new_domain(utf8(b"sub.sub.sub.sub.sub.sub.example.sui")));
+    assert!(domain::to_string(&parent) == utf8(b"sub.sub.sub.sub.sub.example.sui"), 0);
 }

--- a/packages/suins/sources/admin.move
+++ b/packages/suins/sources/admin.move
@@ -6,13 +6,14 @@
 module suins::admin;
 
 use std::string::String;
-use sui::clock::Clock;
-use sui::tx_context::sender;
-use suins::core_config::CoreConfig;
-use suins::domain;
-use suins::registry::Registry;
-use suins::suins::{Self, AdminCap, SuiNS};
-use suins::suins_registration::SuinsRegistration;
+use sui::{clock::Clock, tx_context::sender};
+use suins::{
+    core_config::CoreConfig,
+    domain,
+    registry::Registry,
+    suins::{Self, AdminCap, SuiNS},
+    suins_registration::SuinsRegistration
+};
 
 /// The authorization witness.
 public struct Admin has drop {}

--- a/packages/suins/sources/constants.move
+++ b/packages/suins/sources/constants.move
@@ -23,8 +23,7 @@ const SUI_TLD: vector<u8> = b"sui";
 /// The amount of milliseconds in a year.
 const YEAR_MS: u64 = 365 * 24 * 60 * 60 * 1000;
 /// Default value for the image_url; IPFS hash.
-const DEFAULT_IMAGE: vector<u8> =
-    b"QmaLFg4tQYansFpyRqmDfABdkUVy66dHtpnkH15v1LPzcY";
+const DEFAULT_IMAGE: vector<u8> = b"QmaLFg4tQYansFpyRqmDfABdkUVy66dHtpnkH15v1LPzcY";
 /// 30 day Grace period in milliseconds.
 const GRACE_PERIOD_MS: u64 = 30 * 24 * 60 * 60 * 1000;
 
@@ -75,7 +74,7 @@ public fun subdomain_allow_creation_key(): String { ALLOW_CREATION.to_string() }
 
 /// The NameRecord key that a subdomain can self-renew.
 public fun subdomain_allow_extension_key(): String {
-   ALLOW_TIME_EXTENSION.to_string()
+    ALLOW_TIME_EXTENSION.to_string()
 }
 
 /// A getter for a leaf name record's expiration timestamp.

--- a/packages/suins/sources/controller.move
+++ b/packages/suins/sources/controller.move
@@ -4,13 +4,14 @@
 module suins::controller;
 
 use std::string::String;
-use sui::clock::Clock;
-use sui::tx_context::sender;
-use suins::domain;
-use suins::registry::Registry;
-use suins::subdomain_registration::SubDomainRegistration;
-use suins::suins::{Self, SuiNS};
-use suins::suins_registration::SuinsRegistration;
+use sui::{clock::Clock, tx_context::sender};
+use suins::{
+    domain,
+    registry::Registry,
+    subdomain_registration::SubDomainRegistration,
+    suins::{Self, SuiNS},
+    suins_registration::SuinsRegistration
+};
 
 const AVATAR: vector<u8> = b"avatar";
 const CONTENT_HASH: vector<u8> = b"content_hash";
@@ -74,7 +75,10 @@ public fun set_user_data(
 
     registry.assert_nft_is_authorized(nft, clock);
     let key_bytes = *key.as_bytes();
-    assert!(key_bytes == AVATAR || key_bytes == CONTENT_HASH || key_bytes == WALRUS_SITE_ID, EUnsupportedKey);
+    assert!(
+        key_bytes == AVATAR || key_bytes == CONTENT_HASH || key_bytes == WALRUS_SITE_ID,
+        EUnsupportedKey,
+    );
 
     if (data.contains(&key)) {
         data.remove(&key);

--- a/packages/suins/sources/core_config.move
+++ b/packages/suins/sources/core_config.move
@@ -10,10 +10,8 @@
 module suins::core_config;
 
 use std::string::String;
-use sui::vec_map::{Self, VecMap};
-use sui::vec_set::{Self, VecSet};
-use suins::constants;
-use suins::domain::Domain;
+use sui::{vec_map::{Self, VecMap}, vec_set::{Self, VecSet}};
+use suins::{constants, domain::Domain};
 
 #[error]
 const EInvalidLength: vector<u8> = b"Invalid length for the label part of the domain.";

--- a/packages/suins/sources/deprecated/auction.move
+++ b/packages/suins/sources/deprecated/auction.move
@@ -6,20 +6,23 @@
 #[deprecated(note = b"There is no usable auction module anymore after the initial auction.")]
 module suins::auction;
 
-use std::option::{none, some, is_some};
-use std::string::String;
-use sui::balance::{Self, Balance};
-use sui::clock::Clock;
-use sui::coin::{Self, Coin};
-use sui::event;
-use sui::linked_table::{Self, LinkedTable};
-use sui::sui::SUI;
-use suins::core_config::CoreConfig;
-use suins::domain::{Self, Domain};
-use suins::pricing_config::PricingConfig;
-use suins::registry::Registry;
-use suins::suins::{Self, AdminCap, SuiNS};
-use suins::suins_registration::SuinsRegistration;
+use std::{option::{none, some, is_some}, string::String};
+use sui::{
+    balance::{Self, Balance},
+    clock::Clock,
+    coin::{Self, Coin},
+    event,
+    linked_table::{Self, LinkedTable},
+    sui::SUI
+};
+use suins::{
+    core_config::CoreConfig,
+    domain::{Self, Domain},
+    pricing_config::PricingConfig,
+    registry::Registry,
+    suins::{Self, AdminCap, SuiNS},
+    suins_registration::SuinsRegistration
+};
 
 /// One year is the default duration for a domain.
 const DEFAULT_DURATION: u8 = 1;

--- a/packages/suins/sources/deprecated/config.move
+++ b/packages/suins/sources/deprecated/config.move
@@ -11,7 +11,7 @@ use suins::domain::Domain;
 /// be replaced with any other module providing similar interface
 /// and fitting the needs of the application.
 #[allow(unused_field)]
-public struct Config has store, drop {
+public struct Config has drop, store {
     public_key: vector<u8>,
     three_char_price: u64,
     four_char_price: u64,

--- a/packages/suins/sources/domain.move
+++ b/packages/suins/sources/domain.move
@@ -218,19 +218,7 @@ fun valid_domains() {
     test_valid_domain(b"suins.sui", vector[b"suins", b"sui"]);
     test_valid_domain(
         b"1.2.3.4.5.6.7.8.9.0.sui",
-        vector[
-            b"1",
-            b"2",
-            b"3",
-            b"4",
-            b"5",
-            b"6",
-            b"7",
-            b"8",
-            b"9",
-            b"0",
-            b"sui",
-        ],
+        vector[b"1", b"2", b"3", b"4", b"5", b"6", b"7", b"8", b"9", b"0", b"sui"],
     );
     test_valid_domain(b"pay.mysten.sui", vector[b"pay", b"mysten", b"sui"]);
     test_valid_domain(
@@ -257,11 +245,7 @@ fun test_valid_labels() {
 }
 
 #[test_only]
-fun expect_is_subdomain(
-    domain: vector<u8>,
-    subdomain: vector<u8>,
-    expected: bool,
-) {
+fun expect_is_subdomain(domain: vector<u8>, subdomain: vector<u8>, expected: bool) {
     let domain = new(utf8(domain));
     let subdomain = new(utf8(subdomain));
     assert_eq(is_parent_of(&domain, &subdomain), expected);
@@ -333,11 +317,7 @@ fun split_two_dots() {
 #[test]
 fun split_three_dots() {
     let s = utf8(b"...");
-    let expected = vector[
-        utf8(vector::empty()),
-        utf8(vector::empty()),
-        utf8(vector::empty()),
-    ];
+    let expected = vector[utf8(vector::empty()), utf8(vector::empty()), utf8(vector::empty())];
     let actual = split_by_dot(s);
     assert_eq(actual, expected);
 }

--- a/packages/suins/sources/name_record.move
+++ b/packages/suins/sources/name_record.move
@@ -9,12 +9,11 @@
 module suins::name_record;
 
 use std::string::String;
-use sui::clock::{timestamp_ms, Clock};
-use sui::vec_map::{Self, VecMap};
+use sui::{clock::{timestamp_ms, Clock}, vec_map::{Self, VecMap}};
 use suins::constants;
 
 /// A single record in the registry.
-public struct NameRecord has copy, store, drop {
+public struct NameRecord has copy, drop, store {
     /// The ID of the `SuinsRegistration` assigned to this record.
     ///
     /// The owner of the corresponding `SuinsRegistration` has the rights to
@@ -42,10 +41,7 @@ public fun new(nft_id: ID, expiration_timestamp_ms: u64): NameRecord {
 }
 
 /// Create a `leaf` NameRecord.
-public fun new_leaf(
-    parent_id: ID,
-    target_address: Option<address>,
-): NameRecord {
+public fun new_leaf(parent_id: ID, target_address: Option<address>): NameRecord {
     NameRecord {
         nft_id: parent_id,
         expiration_timestamp_ms: constants::leaf_expiration_timestamp(),
@@ -72,17 +68,11 @@ public fun set_data(self: &mut NameRecord, data: VecMap<String, String>) {
 }
 
 /// Set the `target_address` field of the `NameRecord`.
-public fun set_target_address(
-    self: &mut NameRecord,
-    new_address: Option<address>,
-) {
+public fun set_target_address(self: &mut NameRecord, new_address: Option<address>) {
     self.target_address = new_address;
 }
 
-public fun set_expiration_timestamp_ms(
-    self: &mut NameRecord,
-    expiration_timestamp_ms: u64,
-) {
+public fun set_expiration_timestamp_ms(self: &mut NameRecord, expiration_timestamp_ms: u64) {
     self.expiration_timestamp_ms = expiration_timestamp_ms;
 }
 
@@ -94,10 +84,7 @@ public fun has_expired(self: &NameRecord, clock: &Clock): bool {
 }
 
 /// Check if the record has expired, taking into account the grace period.
-public fun has_expired_past_grace_period(
-    self: &NameRecord,
-    clock: &Clock,
-): bool {
+public fun has_expired_past_grace_period(self: &NameRecord, clock: &Clock): bool {
     (self.expiration_timestamp_ms + constants::grace_period_ms()) < timestamp_ms(clock)
 }
 

--- a/packages/suins/sources/sales/payment.move
+++ b/packages/suins/sources/sales/payment.move
@@ -17,19 +17,17 @@
 */
 module suins::payment;
 
-use std::string::String;
-use std::type_name::{Self, TypeName};
-use sui::clock::Clock;
-use sui::coin::Coin;
-use sui::event;
-use sui::vec_map::{Self, VecMap};
-use suins::constants;
-use suins::core_config::CoreConfig;
-use suins::domain::{Self, Domain};
-use suins::pricing_config::{PricingConfig, RenewalConfig};
-use suins::registry::Registry;
-use suins::suins::SuiNS;
-use suins::suins_registration::SuinsRegistration;
+use std::{string::String, type_name::{Self, TypeName}};
+use sui::{clock::Clock, coin::Coin, event, vec_map::{Self, VecMap}};
+use suins::{
+    constants,
+    core_config::CoreConfig,
+    domain::{Self, Domain},
+    pricing_config::{PricingConfig, RenewalConfig},
+    registry::Registry,
+    suins::SuiNS,
+    suins_registration::SuinsRegistration
+};
 
 #[error]
 const ENotMultipleDiscountsAllowed: vector<u8> = b"Multiple discounts are not allowed";

--- a/packages/suins/sources/subdomain_registration.move
+++ b/packages/suins/sources/subdomain_registration.move
@@ -51,18 +51,11 @@ public(package) fun new(
 
 /// Destroys the wrapper and returns the SuinsRegistration object.
 /// Fails if the subname is not expired.
-public(package) fun burn(
-    name: SubDomainRegistration,
-    clock: &Clock,
-): SuinsRegistration {
+public(package) fun burn(name: SubDomainRegistration, clock: &Clock): SuinsRegistration {
     // tries to unwrap a non-expired subname.
     assert!(name.nft.has_expired(clock), ENameNotExpired);
 
-    let SubDomainRegistration {
-        id,
-        nft,
-    } = name;
-
+    let SubDomainRegistration { id, nft } = name;
     id.delete();
     nft
 }

--- a/packages/suins/sources/suins.move
+++ b/packages/suins/sources/suins.move
@@ -22,10 +22,7 @@
 /// the registry and the balance.
 module suins::suins;
 
-use sui::balance::{Self, Balance};
-use sui::coin::{Self, Coin};
-use sui::dynamic_field as df;
-use sui::sui::SUI;
+use sui::{balance::{Self, Balance}, coin::{Self, Coin}, dynamic_field as df, sui::SUI};
 
 use fun df::add as UID.add;
 use fun df::borrow as UID.borrow;

--- a/packages/suins/sources/suins_registration.move
+++ b/packages/suins/sources/suins_registration.move
@@ -15,8 +15,7 @@ module suins::suins_registration;
 
 use std::string::String;
 use sui::clock::{timestamp_ms, Clock};
-use suins::constants;
-use suins::domain::Domain;
+use suins::{constants, domain::Domain};
 
 /* friend suins::registry; */
 /* friend suins::update_image; */
@@ -63,10 +62,7 @@ public(package) fun set_expiration_timestamp_ms(
 
 /// Updates the `image_url` field for this NFT. Is only called in the
 /// `update_image` for now.
-public(package) fun update_image_url(
-    self: &mut SuinsRegistration,
-    image_url: String,
-) {
+public(package) fun update_image_url(self: &mut SuinsRegistration, image_url: String) {
     self.image_url = image_url;
 }
 
@@ -96,10 +92,7 @@ public fun has_expired(self: &SuinsRegistration, clock: &Clock): bool {
 /// Check whether the `SuinsRegistration` has expired by comparing the
 /// expiration timeout with the current time. This function also takes into
 /// account the grace period.
-public fun has_expired_past_grace_period(
-    self: &SuinsRegistration,
-    clock: &Clock,
-): bool {
+public fun has_expired_past_grace_period(self: &SuinsRegistration, clock: &Clock): bool {
     (self.expiration_timestamp_ms + constants::grace_period_ms()) < timestamp_ms(clock)
 }
 
@@ -146,10 +139,7 @@ public fun set_expiration_timestamp_ms_for_testing(
 }
 
 #[test_only]
-public fun update_image_url_for_testing(
-    self: &mut SuinsRegistration,
-    image_url: String,
-) {
+public fun update_image_url_for_testing(self: &mut SuinsRegistration, image_url: String) {
     update_image_url(self, image_url);
 }
 

--- a/packages/suins/tests/auction_tests.move
+++ b/packages/suins/tests/auction_tests.move
@@ -5,29 +5,28 @@
 module suins::auction_tests;
 
 use std::string::{String, utf8};
-use sui::clock::{Self, Clock};
-use sui::coin::{Self, Coin};
-use sui::sui::SUI;
-use sui::test_scenario::{Self, Scenario, ctx};
-use suins::auction::{
-    Self,
-    App as AuctionApp,
-    place_bid,
-    claim,
-    AuctionHouse,
-    start_auction_and_place_bid,
-    total_balance,
-    admin_finalize_auction,
-    admin_try_finalize_auctions,
-    admin_withdraw_funds,
-    collect_winning_auction_fund
+use sui::{clock::{Self, Clock}, coin::{Self, Coin}, sui::SUI, test_scenario::{Self, Scenario, ctx}};
+use suins::{
+    auction::{
+        Self,
+        App as AuctionApp,
+        place_bid,
+        claim,
+        AuctionHouse,
+        start_auction_and_place_bid,
+        total_balance,
+        admin_finalize_auction,
+        admin_try_finalize_auctions,
+        admin_withdraw_funds,
+        collect_winning_auction_fund
+    },
+    constants::{Self, mist_per_sui},
+    core_config,
+    domain,
+    registry,
+    suins::{Self, SuiNS, AdminCap},
+    suins_registration::SuinsRegistration
 };
-use suins::core_config;
-use suins::constants::{Self, mist_per_sui};
-use suins::domain;
-use suins::registry;
-use suins::suins::{Self, SuiNS, AdminCap};
-use suins::suins_registration::SuinsRegistration;
 
 const SUINS_ADDRESS: address = @0xA001;
 const FIRST_ADDRESS: address = @0xB001;
@@ -129,11 +128,7 @@ fun withdraw_util(scenario: &mut Scenario, sender: address): Coin<SUI> {
     returned_payment
 }
 
-fun admin_collect_fund_util(
-    scenario: &mut Scenario,
-    domain_name: String,
-    clock_tick: u64,
-) {
+fun admin_collect_fund_util(scenario: &mut Scenario, domain_name: String, clock_tick: u64) {
     scenario.next_tx(SUINS_ADDRESS);
     let mut auction_house = scenario.take_shared<AuctionHouse>();
     let mut clock = scenario.take_shared<Clock>();
@@ -150,11 +145,7 @@ fun admin_collect_fund_util(
     test_scenario::return_shared(auction_house);
 }
 
-fun admin_try_finalize_auction_util(
-    scenario: &mut Scenario,
-    domain: String,
-    clock_tick: u64,
-) {
+fun admin_try_finalize_auction_util(scenario: &mut Scenario, domain: String, clock_tick: u64) {
     scenario.next_tx(SUINS_ADDRESS);
     let admin_cap = scenario.take_from_sender<AdminCap>();
     let mut auction_house = scenario.take_shared<AuctionHouse>();

--- a/packages/suins/tests/controller_tests.move
+++ b/packages/suins/tests/controller_tests.move
@@ -4,23 +4,26 @@
 #[test_only]
 module suins::controller_tests;
 
-use std::option::{extract, some, none};
-use std::string::{utf8, String};
-use sui::clock::{Self, Clock};
-use sui::dynamic_field;
-use sui::sui::SUI;
-use sui::test_scenario::{Self, Scenario, ctx};
-use sui::test_utils::{assert_eq, destroy};
-use sui::vec_map::VecMap;
-use suins::constants::{mist_per_sui, year_ms};
-use suins::controller::{Self, ControllerV2};
-use suins::domain::{Self, Domain};
-use suins::register::Register;
-use suins::register_utils::register_util;
-use suins::registry::{Self, Registry, lookup, reverse_lookup};
-use suins::subdomain_registration;
-use suins::suins::{Self, SuiNS, AdminCap};
-use suins::suins_registration::{Self, SuinsRegistration};
+use std::{option::{extract, some, none}, string::{utf8, String}};
+use sui::{
+    clock::{Self, Clock},
+    dynamic_field,
+    sui::SUI,
+    test_scenario::{Self, Scenario, ctx},
+    test_utils::{assert_eq, destroy},
+    vec_map::VecMap
+};
+use suins::{
+    constants::{mist_per_sui, year_ms},
+    controller::{Self, ControllerV2},
+    domain::{Self, Domain},
+    register::Register,
+    register_utils::register_util,
+    registry::{Self, Registry, lookup, reverse_lookup},
+    subdomain_registration,
+    suins::{Self, SuiNS, AdminCap},
+    suins_registration::{Self, SuinsRegistration}
+};
 
 use fun set_target_address_util as Scenario.set_target_address_util;
 use fun set_reverse_lookup_util as Scenario.set_reverse_lookup_util;
@@ -719,7 +722,6 @@ fun test_reverse_reset_when_target_address_changes() {
     scenario.set_object_reverse_lookup_util(&mut uid, FIRST_ADDRESS, DOMAIN_NAME.to_string());
     scenario.lookup_util(DOMAIN_NAME.to_string(), some(uid.to_address()));
     scenario.reverse_lookup_util(uid.to_address(), some(domain::new(DOMAIN_NAME.to_string())));
-
 
     scenario.set_target_address_util(FIRST_ADDRESS, some(FIRST_ADDRESS), 0);
     scenario.reverse_lookup_util(uid.to_address(), none());

--- a/packages/suins/tests/payments/payment_tests.move
+++ b/packages/suins/tests/payments/payment_tests.move
@@ -4,18 +4,17 @@
 #[test_only]
 module suins::payment_tests;
 
-use sui::clock;
-use sui::coin;
-use sui::sui::SUI;
-use sui::test_utils::{assert_eq, destroy};
-use suins::constants;
-use suins::core_config;
-use suins::domain;
-use suins::payment::{Self, PaymentIntent, Receipt};
-use suins::pricing_config::{Self, PricingConfig};
-use suins::registry::{Self, Registry};
-use suins::suins::{Self, SuiNS};
-use suins::suins_registration;
+use sui::{clock, coin, sui::SUI, test_utils::{assert_eq, destroy}};
+use suins::{
+    constants,
+    core_config,
+    domain,
+    payment::{Self, PaymentIntent, Receipt},
+    pricing_config::{Self, PricingConfig},
+    registry::{Self, Registry},
+    suins::{Self, SuiNS},
+    suins_registration
+};
 
 public struct PaymentsApp() has drop;
 public struct DiscountsApp() has drop;

--- a/packages/suins/tests/payments/pricing_tests.move
+++ b/packages/suins/tests/payments/pricing_tests.move
@@ -16,7 +16,7 @@ fun test_e2e() {
 
     let pricing_config = pricing_config::new(
         ranges,
-        vector[10, 20, 30, 45]
+        vector[10, 20, 30, 45],
     );
 
     // test internal values

--- a/packages/suins/tests/test_utils/register.move
+++ b/packages/suins/tests/test_utils/register.move
@@ -5,14 +5,15 @@
 module suins::register;
 
 use std::string::String;
-use sui::clock::Clock;
-use sui::coin::Coin;
-use suins::core_config::CoreConfig;
-use suins::domain;
-use suins::pricing_config::PricingConfig;
-use suins::registry::Registry;
-use suins::suins::{Self, SuiNS};
-use suins::suins_registration::SuinsRegistration;
+use sui::{clock::Clock, coin::Coin};
+use suins::{
+    core_config::CoreConfig,
+    domain,
+    pricing_config::PricingConfig,
+    registry::Registry,
+    suins::{Self, SuiNS},
+    suins_registration::SuinsRegistration
+};
 
 /// Number of years passed is not within [1-5] interval.
 const EInvalidYearsArgument: u64 = 0;

--- a/packages/suins/tests/test_utils/register_utils.move
+++ b/packages/suins/tests/test_utils/register_utils.move
@@ -5,12 +5,8 @@
 module suins::register_utils;
 
 use std::string::String;
-use sui::clock::Clock;
-use sui::coin;
-use sui::test_scenario::{Self, Scenario, ctx};
-use suins::register::register;
-use suins::suins::SuiNS;
-use suins::suins_registration::SuinsRegistration;
+use sui::{clock::Clock, coin, test_scenario::{Self, Scenario, ctx}};
+use suins::{register::register, suins::SuiNS, suins_registration::SuinsRegistration};
 
 const SUINS_ADDRESS: address = @0xA001;
 

--- a/packages/suins/tests/unit/admin_tests.move
+++ b/packages/suins/tests/unit/admin_tests.move
@@ -11,13 +11,8 @@
 module suins::admin_tests;
 
 use std::string::utf8;
-use sui::clock;
-use sui::test_utils::assert_eq;
-use suins::admin::{Self, Admin};
-use suins::constants;
-use suins::domain;
-use suins::registry;
-use suins::suins;
+use sui::{clock, test_utils::assert_eq};
+use suins::{admin::{Self, Admin}, constants, domain, registry, suins};
 
 #[test, expected_failure(abort_code = ::suins::suins::EAppNotAuthorized)]
 fun try_unathorized_fail() {

--- a/packages/suins/tests/unit/core_config_tests.move
+++ b/packages/suins/tests/unit/core_config_tests.move
@@ -3,11 +3,8 @@
 
 module suins::core_config_tests;
 
-use sui::test_utils::assert_eq;
-use sui::vec_map;
-use suins::constants;
-use suins::core_config::{Self, CoreConfig};
-use suins::domain;
+use sui::{test_utils::assert_eq, vec_map};
+use suins::{constants, core_config::{Self, CoreConfig}, domain};
 
 #[test]
 fun test_config_creation_and_field_access() {

--- a/packages/suins/tests/unit/name_record_tests.move
+++ b/packages/suins/tests/unit/name_record_tests.move
@@ -10,13 +10,9 @@
 ///
 module suins::name_record_tests;
 
-use std::option::{none, some};
-use std::string::utf8;
-use sui::clock;
-use sui::test_utils::assert_eq;
-use sui::vec_map;
-use suins::constants;
-use suins::name_record as record;
+use std::{option::{none, some}, string::utf8};
+use sui::{clock, test_utils::assert_eq, vec_map};
+use suins::{constants, name_record as record};
 
 #[test]
 /// Make sure that the fields are empty by default. That they are updated

--- a/packages/suins/tests/unit/registration_nft_tests.move
+++ b/packages/suins/tests/unit/registration_nft_tests.move
@@ -11,11 +11,8 @@
 module suins::registation_nft_tests;
 
 use std::string::{utf8, String};
-use sui::clock::{Self, Clock};
-use sui::test_utils::assert_eq;
-use suins::constants;
-use suins::domain;
-use suins::suins_registration::{Self as nft, SuinsRegistration};
+use sui::{clock::{Self, Clock}, test_utils::assert_eq};
+use suins::{constants, domain, suins_registration::{Self as nft, SuinsRegistration}};
 
 #[test]
 fun test_new() {
@@ -66,12 +63,7 @@ fun test_update_values() {
 
 // === Helpers ===
 
-fun new(
-    domain_name: String,
-    no_years: u8,
-    clock: &Clock,
-    ctx: &mut TxContext,
-): SuinsRegistration {
+fun new(domain_name: String, no_years: u8, clock: &Clock, ctx: &mut TxContext): SuinsRegistration {
     nft::new_for_testing(
         domain::new(domain_name),
         no_years,

--- a/packages/suins/tests/unit/registry_tests.move
+++ b/packages/suins/tests/unit/registry_tests.move
@@ -4,15 +4,15 @@
 #[test_only]
 module suins::registry_tests;
 
-use std::option::some;
-use std::string::utf8;
-use sui::clock::{Self, Clock};
-use sui::test_utils::assert_eq;
-use suins::constants;
-use suins::domain::{Self, Domain};
-use suins::name_record as record;
-use suins::registry::{Self, Registry};
-use suins::suins_registration::{Self as nft, SuinsRegistration};
+use std::{option::some, string::utf8};
+use sui::{clock::{Self, Clock}, test_utils::assert_eq};
+use suins::{
+    constants,
+    domain::{Self, Domain},
+    name_record as record,
+    registry::{Self, Registry},
+    suins_registration::{Self as nft, SuinsRegistration}
+};
 
 // === Registry + Record Addition ===
 

--- a/packages/suins/tests/unit/sub_name_tests.move
+++ b/packages/suins/tests/unit/sub_name_tests.move
@@ -6,9 +6,7 @@ module suins::sub_name_tests;
 
 use std::string::utf8;
 use sui::clock;
-use suins::domain;
-use suins::subdomain_registration as subdomain;
-use suins::suins_registration;
+use suins::{domain, subdomain_registration as subdomain, suins_registration};
 
 #[test]
 fun test_wrap_and_destroy() {
@@ -39,12 +37,7 @@ fun test_wrap_and_destroy() {
     clock.destroy_for_testing();
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = suins::subdomain_registration::ENotSubdomain,
-    ),
-]
+#[test, expected_failure(abort_code = suins::subdomain_registration::ENotSubdomain)]
 fun try_wrap_non_subdomain() {
     let mut ctx = tx_context::dummy();
     let clock = clock::create_for_testing(&mut ctx);
@@ -81,12 +74,7 @@ fun try_wrap_expired_subname() {
     abort 1337
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = suins::subdomain_registration::ENameNotExpired,
-    ),
-]
+#[test, expected_failure(abort_code = suins::subdomain_registration::ENameNotExpired)]
 fun try_unwrap_non_expired_subdomain() {
     let mut ctx = tx_context::dummy();
     let clock = clock::create_for_testing(&mut ctx);

--- a/packages/suins/tests/unit/suins_tests.move
+++ b/packages/suins/tests/unit/suins_tests.move
@@ -5,15 +5,12 @@
 ///
 module suins::suins_tests;
 
-use sui::balance;
-use sui::coin;
-use sui::sui::SUI;
-use sui::test_utils::assert_eq;
+use sui::{balance, coin, sui::SUI, test_utils::assert_eq};
 use suins::suins::{Self, AdminCap, SuiNS};
 
 // === Config management ===
 
-public struct TestConfig has store, drop { a: u8 }
+public struct TestConfig has drop, store { a: u8 }
 public struct USDC has drop {}
 
 #[test]

--- a/packages/temp_subdomain_proxy/sources/subdomain_proxy.move
+++ b/packages/temp_subdomain_proxy/sources/subdomain_proxy.move
@@ -13,9 +13,7 @@ module temp_subdomain_proxy::subdomain_proxy;
 use std::string::String;
 use subdomains::subdomains;
 use sui::clock::Clock;
-use suins::controller;
-use suins::subdomain_registration::SubDomainRegistration;
-use suins::suins::SuiNS;
+use suins::{controller, subdomain_registration::SubDomainRegistration, suins::SuiNS};
 
 public fun new(
     suins: &mut SuiNS,

--- a/packages/token/sources/ns.move
+++ b/packages/token/sources/ns.move
@@ -5,9 +5,7 @@
 /// This will validate that the supply of minted NS cannot change.
 module token::ns;
 
-use sui::coin::{Self, Coin, TreasuryCap};
-use sui::dynamic_object_field as dof;
-use sui::url;
+use sui::{coin::{Self, Coin, TreasuryCap}, dynamic_object_field as dof, url};
 
 const TOTAL_SUPPLY_TO_MINT: u64 = 500_000_000 * 1_000_000;
 const DECIMALS: u8 = 6;
@@ -25,7 +23,7 @@ public struct ProtectedTreasury has key {
 
 /// The dynamic object field key for the `TreasuryCap`.
 /// That allows us to easily look-up the `TreasuryCap` from the `ProtectedTreasury` off-chain.
-public struct TreasuryCapKey has copy, store, drop {}
+public struct TreasuryCapKey has copy, drop, store {}
 
 #[allow(unused_function, lint(share_owned))]
 fun init(otw: NS, ctx: &mut TxContext) {

--- a/packages/voting/sources/constants.move
+++ b/packages/voting/sources/constants.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module suins_voting::constants;
 
 /// The minimum voting period in milliseconds. (1 day)

--- a/packages/voting/sources/early_voting/early_voting.move
+++ b/packages/voting/sources/early_voting/early_voting.move
@@ -1,14 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Early voting is the simplest form of voting, where proposals are voted on by
 /// the community.
 /// This is a simple voting mechanism, without complex actions.
 module suins_voting::early_voting;
 
-use suins_voting::governance::{NSGovernance, NSGovernanceCap};
-use suins_voting::proposal::Proposal;
+use suins_voting::{governance::{NSGovernance, NSGovernanceCap}, proposal::Proposal};
 
 #[error]
-const ECannotHaveParallelProposals: vector<u8> =
-    b"Cannot have parallel proposals";
+const ECannotHaveParallelProposals: vector<u8> = b"Cannot have parallel proposals";
 
 public struct ProposalPointer has store {
     proposal_id: ID,
@@ -40,10 +41,7 @@ public fun add_proposal(
     // avoid 2 parallel proposals.
     if (early_voting.0.length() > 0) {
         let last_proposal = early_voting.0.borrow(early_voting.0.length() - 1);
-        assert!(
-            last_proposal.end_time < proposal.start_time_ms(),
-            ECannotHaveParallelProposals,
-        );
+        assert!(last_proposal.end_time < proposal.start_time_ms(), ECannotHaveParallelProposals);
     };
 
     early_voting

--- a/packages/voting/sources/early_voting/voting_option.move
+++ b/packages/voting/sources/early_voting/voting_option.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module suins_voting::voting_option;
 
 use std::string::String;
@@ -10,7 +13,7 @@ const ABSTAIN_OPTION: vector<u8> = b"Abstain";
 const THRESHOLD_NOT_REACHED: vector<u8> = b"Threshold not reached";
 const TIE_REJECTED: vector<u8> = b"Vote rejected due to tie";
 
-public struct VotingOption(String) has copy, store, drop;
+public struct VotingOption(String) has copy, drop, store;
 
 /// The default voting is YES, NO, Abstain.
 public fun default_options(): VecSet<VotingOption> {

--- a/packages/voting/sources/governance.move
+++ b/packages/voting/sources/governance.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// The governance module for SuiNS.
 ///
 /// The governance module is used to:
@@ -14,8 +17,7 @@
 /// is a simple voting mechanism, without complex actions.
 module suins_voting::governance;
 
-use sui::dynamic_field as df;
-use sui::package;
+use sui::{dynamic_field as df, package};
 
 use fun df::add as UID.add;
 use fun df::borrow as UID.borrow;
@@ -38,7 +40,7 @@ const QUORUM_THRESHOLD: u64 = 1_500_000 * 1_000_000;
 public struct GOVERNANCE has drop {}
 
 /// The KEY for any application stored under the governance object.
-public struct Application<phantom K> has copy, store, drop {}
+public struct Application<phantom K> has copy, drop, store {}
 
 /// The NSGovernance object, which holds all the governance related objects /
 /// capabilities.

--- a/packages/voting/sources/leaderboard.move
+++ b/packages/voting/sources/leaderboard.move
@@ -1,16 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module suins_voting::leaderboard;
 
 #[error]
-const EInvalidMaxSize: vector<u8> =
-    b"Maximum leaderboard size cannot exceed 100 entries.";
+const EInvalidMaxSize: vector<u8> = b"Maximum leaderboard size cannot exceed 100 entries.";
 
 /// The maximum number of entries in the leaderboard
 /// Added to preserve size limits.
 const MAX_ENTRIES: u64 = 100;
 
-public struct LeaderboardEntry(address, u64) has copy, store, drop;
+public struct LeaderboardEntry(address, u64) has copy, drop, store;
 
-public struct Leaderboard has store, drop {
+public struct Leaderboard has drop, store {
     entries: vector<LeaderboardEntry>,
     max_size: u64,
 }
@@ -41,16 +43,10 @@ public fun entries(leaderboard: &Leaderboard): vector<LeaderboardEntry> {
 /// If the address exists in the leaderboard, we know that the new value
 /// is greater than the existing value (so it should belong here),
 /// so we can just update it.
-public fun add_if_eligible(
-    leaderboard: &mut Leaderboard,
-    addr: address,
-    value: u64,
-) {
+public fun add_if_eligible(leaderboard: &mut Leaderboard, addr: address, value: u64) {
     // If the address is already in the leaderboard, add the value to the
     // existing entry
-    let mut addr_idx = leaderboard
-        .entries()
-        .find_index!(|val| val.addr() == addr);
+    let mut addr_idx = leaderboard.entries().find_index!(|val| val.addr() == addr);
 
     if (addr_idx.is_some()) {
         leaderboard.entries[addr_idx.extract()].1 = value;
@@ -63,10 +59,8 @@ public fun add_if_eligible(
 
     // If the leaderboard is full and the last entry is greater than the
     // entry we try to insert, we can skip the insertion
-    if (
-        is_full &&
-        leaderboard.entries[leaderboard.max_size - 1].1 >= value
-    ) return;
+    if (is_full &&
+        leaderboard.entries[leaderboard.max_size - 1].1 >= value) return;
 
     // If the leaderboard is full, remove the last entry
     if (is_full) {
@@ -83,9 +77,7 @@ public fun sort(leaderboard: &mut Leaderboard) {
 
     while (i < leaderboard.entries.length()) {
         let mut j = i;
-        while (
-            j > 0 && leaderboard.entries[j-1].value() < leaderboard.entries[j].value()
-        ) {
+        while (j > 0 && leaderboard.entries[j-1].value() < leaderboard.entries[j].value()) {
             leaderboard.entries.swap(j-1, j);
             j = j - 1;
         };

--- a/packages/voting/tests/early_voting_tests.move
+++ b/packages/voting/tests/early_voting_tests.move
@@ -1,15 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module suins_voting::early_voting_tests;
 
-use sui::clock::{Self, Clock};
-use sui::coin::{Self, Coin};
-use sui::test_scenario::{Self as ts, Scenario};
-use sui::test_utils::destroy;
-use suins_voting::constants::min_voting_period_ms;
-use suins_voting::early_voting;
-use suins_voting::governance::{Self, NSGovernance, NSGovernanceCap};
-use suins_voting::proposal::Proposal;
-use suins_voting::proposal_tests;
-use suins_voting::voting_option;
+use sui::{
+    clock::{Self, Clock},
+    coin::{Self, Coin},
+    test_scenario::{Self as ts, Scenario},
+    test_utils::destroy
+};
+use suins_voting::{
+    constants::min_voting_period_ms,
+    early_voting,
+    governance::{Self, NSGovernance, NSGovernanceCap},
+    proposal::Proposal,
+    proposal_tests,
+    voting_option
+};
 use token::ns::NS;
 
 const ADMIN: address = @0x0;
@@ -206,9 +213,7 @@ fun test_e2e_no_quorum() {
 
         assert!(coin.value() == 900_000 * DECIMALS);
 
-        assert!(
-            proposal.winning_option().borrow() == voting_option::threshold_not_reached(),
-        );
+        assert!(proposal.winning_option().borrow() == voting_option::threshold_not_reached());
 
         destroy(coin);
         ts::return_shared(proposal);
@@ -279,9 +284,7 @@ fun test_e2e_tie() {
 
         assert!(coin.value() == 4_000_000 * DECIMALS);
 
-        assert!(
-            proposal.winning_option().borrow() == voting_option::tie_rejected(),
-        );
+        assert!(proposal.winning_option().borrow() == voting_option::tie_rejected());
 
         destroy(coin);
         ts::return_shared(proposal);
@@ -352,9 +355,7 @@ fun test_e2e_abstain_bypassed() {
 
         assert!(coin.value() == 3_000_000 * DECIMALS);
 
-        assert!(
-            proposal.winning_option().borrow() == voting_option::no_option(),
-        );
+        assert!(proposal.winning_option().borrow() == voting_option::no_option());
 
         destroy(coin);
         ts::return_shared(proposal);
@@ -384,12 +385,7 @@ fun add_second_proposal_after_first_is_completed() {
     test.cleanup();
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::suins_voting::early_voting::ECannotHaveParallelProposals,
-    ),
-]
+#[test, expected_failure(abort_code = ::suins_voting::early_voting::ECannotHaveParallelProposals)]
 fun test_try_to_add_parallel_proposals() {
     let mut test = prepare_early_voting();
     test.ts.next_tx(ADMIN);

--- a/packages/voting/tests/leaderboard_tests.move
+++ b/packages/voting/tests/leaderboard_tests.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 module suins_voting::leaderboard_tests;
 
 use suins_voting::leaderboard;
@@ -22,22 +25,12 @@ fun test_multi_insertions() {
     assert!(leaderboard.entries()[2].value() == 25);
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::suins_voting::leaderboard::EInvalidMaxSize,
-    ),
-]
+#[test, expected_failure(abort_code = ::suins_voting::leaderboard::EInvalidMaxSize)]
 fun create_zero_sized_leaderboard() {
     let _leaderboard = leaderboard::new(0);
 }
 
-#[
-    test,
-    expected_failure(
-        abort_code = ::suins_voting::leaderboard::EInvalidMaxSize,
-    ),
-]
+#[test, expected_failure(abort_code = ::suins_voting::leaderboard::EInvalidMaxSize)]
 fun create_too_large_leaderboard() {
     let _leaderboard = leaderboard::new(1000);
 }

--- a/packages/voting/tests/token.move
+++ b/packages/voting/tests/token.move
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// This module will be completely removed.
 /// This is only added to simulate a demo token,
 /// and allow for testing the voting module.
@@ -36,11 +39,7 @@ fun init(witness: TOKEN, ctx: &mut TxContext) {
     });
 }
 
-public fun mint(
-    faucet: &mut FaucetForTesting,
-    amount: u64,
-    ctx: &mut TxContext,
-) {
+public fun mint(faucet: &mut FaucetForTesting, amount: u64, ctx: &mut TxContext) {
     transfer::public_transfer(faucet.treasury.mint(amount, ctx), ctx.sender());
 }
 


### PR DESCRIPTION
- formats the codebase
- adds missing license headers
- sets up a CI that checks Move formatting
- adds a single `.prettierrc` to align formatting between packages