### PR TITLE
Add backlinks from docs to the Move Registry frontend.

### DIFF
--- a/documentation/pages/move-registry/design.mdx
+++ b/documentation/pages/move-registry/design.mdx
@@ -5,7 +5,7 @@ import { Callout } from 'nextra/components'
 
 # Design of the Move Registry
 
-The Move Registry (MVR, pronounced "mover") consists of two independent components:
+The [Move Registry](https://moveregistry.com) (MVR, pronounced "mover") consists of two independent components:
 
 - `PackageInfo` registration: Exists independently on each network.
 - MVR registration: A single source of truth located on Mainnet.

--- a/documentation/pages/move-registry/maintainer-practices.mdx
+++ b/documentation/pages/move-registry/maintainer-practices.mdx
@@ -4,7 +4,7 @@ import Beta from '../../components/beta'
 
 # Best Practices
 
-For package authors and maintainers, the following best practices are recommended for working with the Move Registry. Following these tips ensures that other builders can use your package as intended.
+For package authors and maintainers, the following best practices are recommended for working with the [Move Registry](https://moveregistry.com). Following these tips ensures that other builders can use your package as intended.
 
 ## Automated Address Management
 

--- a/documentation/pages/move-registry/tooling.mdx
+++ b/documentation/pages/move-registry/tooling.mdx
@@ -5,7 +5,7 @@ import { Callout } from 'nextra/components'
 
 # Tooling
 
-Two main tools are available for use with the Move Registry (MVR):
+Two main tools are available for use with the [Move Registry](https://moveregistry.com) (MVR):
 
 - [A plugin](./tooling/typescript-sdk.mdx) for the Sui TypeScript SDK that enables building programmable transaction blocks (PTBs) using MVR names.
 - An [MVR CLI tool](./tooling/mvr-cli.mdx) for Move development.


### PR DESCRIPTION
This change adds some links to the Move Registry frontend from our docs, making it easier for people to navigate to the frontend if they find the docs on search.