### PR TITLE
[SuiNS indexer] - dedupe commit data.

### DIFF
--- a/indexer/src/models.rs
+++ b/indexer/src/models.rs
@@ -30,6 +30,20 @@ pub struct VerifiedDomain {
     pub subdomain_wrapper_id: Option<String>,
 }
 
+impl VerifiedDomain {
+    pub fn merge(self, other: VerifiedDomain) -> VerifiedDomain {
+        let (mut new, old) = if self.last_checkpoint_updated > other.last_checkpoint_updated {
+            (self, other)
+        } else {
+            (other, self)
+        };
+        if new.subdomain_wrapper_id.is_none() {
+            new.subdomain_wrapper_id = old.subdomain_wrapper_id;
+        }
+        new
+    }
+}
+
 #[derive(FieldCount, Clone)]
 pub struct SuinsCheckpointData {
     pub updates: Vec<VerifiedDomain>,


### PR DESCRIPTION
dedupe data before commit to prevent affecting same row twice in the same transaction