### PR TITLE
fix: rename getRenewalPricelist to getRenewalPriceList 🛠️

### DIFF
--- a/documentation/pages/developer/sdk/querying.mdx
+++ b/documentation/pages/developer/sdk/querying.mdx
@@ -46,10 +46,10 @@ console.log(priceList);
 
 ## Query active renewals pricing
 
-Call the `getRenewalPricelist` method on the `SuinsClient` instance to query the active renewals price list.
+Call the `getRenewalPriceList` method on the `SuinsClient` instance to query the active renewals price list.
 
 ```js
-const renewalPriceList = await suinsClient.getRenewalPricelist();
+const renewalPriceList = await suinsClient.getRenewalPriceList();
 console.log(renewalPriceList);
 
 // ([domain_length_from, domain_length_to]: price. Prices are in USDC MIST; 1 USDC = 1_000_000 MIST)


### PR DESCRIPTION
Fixes capitalization mismatch in documentation for `getRenewalPriceList` method.

- SDK function uses camelCase: (see [SuinsClient](https://github.com/MystenLabs/ts-sdks/blob/2e299b5e65a63b26b0d8a31957a0308e7c744d9c/packages/suins/src/suins-client.ts#L111))
- Documentation incorrectly referenced: `getRenewalPricelist`
- Updated docs to match actual method name