### PR TITLE
fix: bump Rust version for Docker builds

### DIFF
--- a/docker/suins-indexer/Dockerfile
+++ b/docker/suins-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87.0 AS builder
+FROM rust:1.90.0-bullseye AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION


### PR DESCRIPTION
## Description
The recent bump of the Sui deps pulled in changes that require 1.90 to build.

## Test plan
CI