### PR TITLE
docs: Log user-agent on feedback events for agent identification

### DIFF
--- a/documentation/site/src/components/PushFeedback/index.tsx
+++ b/documentation/site/src/components/PushFeedback/index.tsx
@@ -15,6 +15,22 @@ export default function FeedbackWidget() {
     useEffect(() => {
         if (typeof window !== 'undefined') {
             defineCustomElements(window);
+
+            const handleFeedback = () => {
+                const instance = (window as any).__plausible_instance__;
+                const track = instance?.track;
+                if (typeof track === 'function') {
+                    track('Feedback', {
+                        props: {
+                            user_agent: navigator.userAgent.substring(0, 150),
+                            page: window.location.pathname,
+                        },
+                    });
+                }
+            };
+
+            document.addEventListener('feedbackSent', handleFeedback);
+            return () => document.removeEventListener('feedbackSent', handleFeedback);
         }
     }, []);
 


### PR DESCRIPTION
## Summary
- Fires a Plausible custom event (`Feedback`) with `user_agent` and `page` props when the PushFeedback widget submits
- Enables identifying which AI agents are interacting with the feedback widget

## Test plan
- [ ] Verify docs site builds
- [ ] Submit feedback and confirm `Feedback` event appears in Plausible with `user_agent` prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)