### PR TITLE
docs: improve search result display and fix garbled titles

### DIFF
--- a/documentation/site/src/components/Search/CustomHitsContent.tsx
+++ b/documentation/site/src/components/Search/CustomHitsContent.tsx
@@ -4,7 +4,7 @@
 import React from "react";
 import { useHits } from "react-instantsearch";
 import { useHistory } from "@docusaurus/router";
-import { truncateAtWord, getDeepestHierarchyLabel } from "./utils";
+import { truncateAtWord, getDeepestHierarchyLabel, getHierarchyBreadcrumbs, cleanTooltipText } from "./utils";
 
 export default function CustomHitsContent({ name }) {
   const { hits: items } = useHits();
@@ -52,25 +52,31 @@ export default function CustomHitsContent({ name }) {
   return (
     <>
       {Object.entries(grouped).map(([key, group], index) => {
+        const pageCrumbs = getHierarchyBreadcrumbs(group[0].hierarchy);
+        const pageTitle =
+          pageCrumbs.length > 0
+            ? pageCrumbs[Math.min(1, pageCrumbs.length - 1)]
+            : "[no title]";
         return (
           <div
             className="p-6 pb-[40px] mb-6 bg-suins-gray-5 dark:bg-suins-white-10 rounded-[20px]"
             key={index}
           >
             <div className="text-xl text-suins-orange font-semibold mb-4">
-              {group[0].hierarchy?.lvl1 ||
-                group[0].hierarchy?.lvl0 ||
-                "[no title]"}
+              {pageTitle}
             </div>
+            {pageCrumbs.length > 0 && (
+              <div className="text-xs text-suins-gray-50 dark:text-suins-gray-50 mb-4">
+                {pageCrumbs.join(" > ")}
+              </div>
+            )}
             <div className="">
               {group.map((hit, i) => {
-                const level = hit.type;
-                let sectionTitle = hit.lvl0;
-                if (level === "content") {
-                  sectionTitle = getDeepestHierarchyLabel(hit.hierarchy);
-                } else {
-                  sectionTitle = hit.hierarchy?.[level] || level;
-                }
+                const hitCrumbs = getHierarchyBreadcrumbs(hit.hierarchy);
+                const sectionTitle =
+                  hitCrumbs.length > 0
+                    ? hitCrumbs[hitCrumbs.length - 1]
+                    : cleanTooltipText(getDeepestHierarchyLabel(hit.hierarchy));
 
                 const hitHost = new URL(hit.url).host;
                 const isInternal = hitHost === currentHost;

--- a/documentation/site/src/components/Search/SearchModal.tsx
+++ b/documentation/site/src/components/Search/SearchModal.tsx
@@ -9,7 +9,7 @@ import {
   useInstantSearch,
   Index,
 } from "react-instantsearch";
-import { truncateAtWord, getDeepestHierarchyLabel } from "./utils";
+import { truncateAtWord, getDeepestHierarchyLabel, getHierarchyBreadcrumbs, cleanTooltipText } from "./utils";
 import ControlledSearchBox from "./ControlledSearchBox";
 import TabbedResults from "./TabbedResults";
 
@@ -46,38 +46,32 @@ const indices = [
 ];
 
 function HitItem({ hit }: { hit: any }) {
-  const level = hit.type;
-  let sectionTitle = hit.lvl0;
-  if (level === "content") {
-    sectionTitle = getDeepestHierarchyLabel(hit.hierarchy);
-  } else {
-    sectionTitle = hit.hierarchy?.[level] || level;
-  }
+  const crumbs = getHierarchyBreadcrumbs(hit.hierarchy);
+  const title = crumbs.length > 0 ? crumbs[crumbs.length - 1] : cleanTooltipText(hit.hierarchy?.lvl0 || "Untitled");
+  const breadcrumb = crumbs.length > 1 ? crumbs.slice(0, -1) : [];
+
   return (
-    <div className="modal-result">
-      <a
-        href={hit.url}
-        className="text-blue-600 dark:text-suins-green dark:hover:text-suins-green-light font-medium"
-      >
-        {hit.title}
-      </a>
-      <a
-        href={hit.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-base text-blue-600 dark:text-suins-green dark:hover:text-suins-green-light underline pb-2"
-      >
-        {sectionTitle}
-      </a>
-      <p
-        className="text-sm text-suins-gray-60 dark:text-suins-white-80"
-        dangerouslySetInnerHTML={{
-          __html: hit.content
-            ? truncateAtWord(hit._highlightResult.content.value, 100)
-            : "",
-        }}
-      ></p>
-    </div>
+    <a
+      href={hit.url}
+      className="modal-result block px-4 py-3 -mx-2 rounded-lg no-underline hover:bg-suins-gray-5 dark:hover:bg-suins-white-10 transition-colors"
+    >
+      {breadcrumb.length > 0 && (
+        <div className="text-xs text-suins-gray-50 dark:text-suins-gray-50 mb-1 truncate">
+          {breadcrumb.join(" > ")}
+        </div>
+      )}
+      <div className="text-sm font-medium text-gray-900 dark:text-white">
+        {title}
+      </div>
+      {hit.content && (
+        <p
+          className="text-xs text-suins-gray-60 dark:text-suins-white-80 mt-1 mb-0 line-clamp-2"
+          dangerouslySetInnerHTML={{
+            __html: truncateAtWord(hit._highlightResult.content.value, 120),
+          }}
+        />
+      )}
+    </a>
   );
 }
 
@@ -159,7 +153,6 @@ export default function MultiIndexSearchModal({
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden";
-      console.log('SearchModal theme =', document.documentElement.getAttribute('data-theme'));
       // Focus the search input when modal opens
       setTimeout(() => {
         searchBoxRef.current?.focus();
@@ -171,6 +164,15 @@ export default function MultiIndexSearchModal({
       document.body.style.overflow = "";
     };
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
 
   const activeMeta = {
     suins_docs: null,
@@ -185,17 +187,17 @@ export default function MultiIndexSearchModal({
 
   if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 bg-suins-gray-70 dark:bg-suins-gray-90/80 z-50 flex justify-center p-4">
-      <div className="bg-white dark:bg-[var(--ifm-background-color)] w-full max-w-3xl px-6 rounded-lg shadow-md max-h-[600px] flex flex-col">
+    <div className="fixed inset-0 bg-suins-gray-70 dark:bg-suins-gray-90/80 z-50 flex justify-center items-start pt-[10vh]" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="bg-white dark:bg-[var(--ifm-background-color)] w-full max-w-4xl rounded-lg shadow-md max-h-[600px] flex flex-col">
         <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
           <InstantSearch searchClient={searchClient} indexName={activeIndex}>
-            <div className="bg-white dark:bg-[var(--ifm-background-color)] rounded-t sticky top-0 z-10">
+            <div className="bg-white dark:bg-[var(--ifm-background-color)] rounded-t sticky top-0 z-10 px-6">
               <div className="bg-white dark:bg-[var(--ifm-background-color)] h-8 flex justify-end">
                 <button
                   onClick={onClose}
-                  className="bg-transparent border-none outline-none text-sm underline cursor-pointer"
+                  className="bg-transparent border-none outline-none text-xs text-suins-gray-50 hover:text-suins-gray-60 cursor-pointer"
                 >
-                  Close
+                  ESC
                 </button>
               </div>
               <ControlledSearchBox
@@ -205,8 +207,8 @@ export default function MultiIndexSearchModal({
                 inputRef={searchBoxRef}
               />
               {query.length < 3 && (
-                <p className="text-sm text-suins-gray-50 dark:text-suins-gray-50 pl-4 mb-2 -mt-6">
-                  Three characters initiates search...
+                <p className="text-xs text-suins-gray-50 dark:text-suins-gray-50 pl-4 mb-2 -mt-6">
+                  Type at least 3 characters to search
                 </p>
               )}
               <TabbedResults
@@ -219,30 +221,32 @@ export default function MultiIndexSearchModal({
                 }))}
               />
             </div>
-            {indices.map((index) => (
-              <Index indexName={index.indexName} key={index.indexName}>
-                <ResultsUpdater
-                  indexName={index.indexName}
-                  onUpdate={(indexName, count) =>
-                    setTabCounts((prev) => ({ ...prev, [indexName]: count }))
-                  }
-                />
-                {index.indexName === activeIndex && (
-                  <>
-                    <HitsList scrollContainerRef={scrollContainerRef} />
-                    <EmptyState label={index.label} />
-                  </>
-                )}
-              </Index>
-            ))}
+            <div className="px-6 pb-4">
+              {indices.map((index) => (
+                <Index indexName={index.indexName} key={index.indexName}>
+                  <ResultsUpdater
+                    indexName={index.indexName}
+                    onUpdate={(indexName, count) =>
+                      setTabCounts((prev) => ({ ...prev, [indexName]: count }))
+                    }
+                  />
+                  {index.indexName === activeIndex && (
+                    <>
+                      <HitsList scrollContainerRef={scrollContainerRef} />
+                      <EmptyState label={index.label} />
+                    </>
+                  )}
+                </Index>
+              ))}
+            </div>
           </InstantSearch>
         </div>
-        <div className="h-14 bg-[var(--ifm-background-color)] flex items-center justify-between text-sm border-t border-solid border-suins-gray-50 border-b-transparent border-l-transparent border-r-transparent">
+        <div className="h-12 bg-[var(--ifm-background-color)] flex items-center justify-between text-xs border-t border-solid border-suins-gray-50 border-b-transparent border-l-transparent border-r-transparent px-6">
           <a
             href={`/search?q=${encodeURIComponent(query)}`}
             className="wal-link-hover dark:text-suins-link dark:hover:text-suins-green underline"
           >
-            Go to full search page
+            View all results
           </a>
           {activeMeta && (
             <a

--- a/documentation/site/src/components/Search/utils.tsx
+++ b/documentation/site/src/components/Search/utils.tsx
@@ -24,3 +24,33 @@ export function getDeepestHierarchyLabel(hierarchy) {
 
   return lastValue || hierarchy.lvl6 || "";
 }
+
+/**
+ * Strip tooltip text injected by the Algolia crawler.
+ * Pattern: a word is immediately followed by itself + a capital-letter
+ * definition ending in a period.
+ */
+export function cleanTooltipText(text: string): string {
+  let cleaned = text.replace(/\u200B/g, "");
+  cleaned = cleaned.replace(/(\b\w{2,})\1[A-Z][^.]*\.\s?/g, "$1 ");
+  return cleaned.trim();
+}
+
+/**
+ * Build an ordered breadcrumb array from a DocSearch hierarchy object.
+ * Deduplicates adjacent identical levels. Strips crawler tooltip artefacts.
+ */
+export function getHierarchyBreadcrumbs(hierarchy): string[] {
+  if (!hierarchy) return [];
+  const levels = ["lvl0", "lvl1", "lvl2", "lvl3", "lvl4", "lvl5", "lvl6"];
+  const crumbs: string[] = [];
+  for (const lvl of levels) {
+    const raw = hierarchy[lvl];
+    if (raw == null) break;
+    const value = cleanTooltipText(raw);
+    if (crumbs.length === 0 || crumbs[crumbs.length - 1] !== value) {
+      crumbs.push(value);
+    }
+  }
+  return crumbs;
+}

--- a/documentation/site/src/css/custom.css
+++ b/documentation/site/src/css/custom.css
@@ -232,7 +232,9 @@ html[data-theme='dark'] .DocSearch-Search-Icon path {
 }
 
 .modal-result mark {
-  @apply bg-suins-green-light;
+  background: rgba(41, 141, 255, 0.3);
+  color: inherit;
+  border-radius: 2px;
 }
 
 .ais-Pagination-list {


### PR DESCRIPTION
## Summary
- Strip inline tooltip text that the Algolia crawler concatenates into hierarchy values, producing garbled titles
- Replace the dual-link modal search result layout with a clean breadcrumb > title > snippet card
- Widen the search modal (`max-w-3xl` to `max-w-4xl`) to prevent tab labels from wrapping
- Improve text contrast across both the search modal and full search page
- Add ESC key and click-outside-to-close to the search modal
- Remove stale `console.log` debug statement

Mirrors MystenLabs/sui#26617

## Test plan
- [ ] Open search modal, search for "test" — titles should be clean, no tooltip text
- [ ] Verify tab labels fit on one line
- [ ] Verify breadcrumbs, titles, and snippets are readable in both light and dark mode
- [ ] Navigate to `/search?q=test` and verify full search page results are also clean
- [ ] Press ESC or click backdrop to close the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)