### PR TITLE
feat: enable OpenInAgentButton in code blocks

### DIFF
--- a/documentation/site/src/css/custom.css
+++ b/documentation/site/src/css/custom.css
@@ -321,7 +321,8 @@ img {
 }
 
 /* Force code block buttons to always be visible (not just on hover) */
-[class*="buttonGroup_"] {
+[class*="buttonGroup_"] button,
+[class*="buttonGroup_"] span {
   opacity: 1 !important;
   transition: none !important;
 }

--- a/documentation/site/src/css/custom.css
+++ b/documentation/site/src/css/custom.css
@@ -319,3 +319,9 @@ img {
 [data-theme='dark'] .lightToggleIcon_pgEs {
   color: #ffffff;
 }
+
+/* Force code block buttons to always be visible (not just on hover) */
+[class*="buttonGroup_"] {
+  opacity: 1 !important;
+  transition: none !important;
+}

--- a/documentation/site/src/shared/components/OpenInAgentButton/index.tsx
+++ b/documentation/site/src/shared/components/OpenInAgentButton/index.tsx
@@ -135,6 +135,47 @@ const GEMINI_PATH = [
   " 15.866 10.134C12 6.268 12 0 12 0Z",
 ].join("");
 
+/* ---------- prompt presets ---------- */
+
+/**
+ * Prompt presets configurable per code block via the `agentPrompt` metastring.
+ *
+ * Usage in markdown:
+ *   ```move agentPrompt="build"
+ *   module hello::world { ... }
+ *   ```
+ *
+ * Add new presets here as needed. The key is the value authors pass in
+ * `agentPrompt="<key>"`. The value is a function receiving (code, lang)
+ * that returns the full prompt string.
+ */
+const PROMPT_PRESETS: Record<string, (code: string, lang: string) => string> = {
+  explain: (code, lang) => {
+    const l = lang ? ` ${lang}` : "";
+    return `Explain this${l} code:\n\n\`\`\`${lang}\n${code}\n\`\`\``;
+  },
+  build: (code, lang) =>
+    `Use this prompt for building on Sui:\n\n\`\`\`${lang}\n${code}\n\`\`\``,
+};
+
+const DEFAULT_PRESET = "explain";
+
+/** Walk up from `start` to find the nearest `data-agent-prompt` attribute. */
+function getNearestPromptPreset(start: HTMLElement | null): string {
+  let el: HTMLElement | null = start;
+  while (el) {
+    const preset = el.getAttribute("data-agent-prompt");
+    if (preset) return preset;
+    el = el.parentElement;
+  }
+  return DEFAULT_PRESET;
+}
+
+function buildPrompt(code: string, lang: string, preset: string): string {
+  const fn = PROMPT_PRESETS[preset] ?? PROMPT_PRESETS[DEFAULT_PRESET];
+  return fn(code, lang);
+}
+
 /* ---------- agent definitions ---------- */
 
 interface AgentItem {
@@ -142,7 +183,7 @@ interface AgentItem {
   title: string;
   description: string;
   icon: ReactNode;
-  url: (code: string, lang: string) => string;
+  url: (code: string, lang: string, preset: string) => string;
 }
 
 const AGENTS: AgentItem[] = [
@@ -162,11 +203,8 @@ const AGENTS: AgentItem[] = [
         <path d={CLAUDE_PATH} />
       </svg>
     ),
-    url: (code, lang) => {
-      const l = lang ? ` ${lang}` : "";
-      const prompt = `Explain this${l} code:\n\n\`\`\`${lang}\n${code}\n\`\`\``;
-      return `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
-    },
+    url: (code, lang, preset) =>
+      `https://claude.ai/new?q=${encodeURIComponent(buildPrompt(code, lang, preset))}`,
   },
   {
     id: "chatgpt",
@@ -184,11 +222,8 @@ const AGENTS: AgentItem[] = [
         <path d={CHATGPT_PATH} />
       </svg>
     ),
-    url: (code, lang) => {
-      const l = lang ? ` ${lang}` : "";
-      const prompt = `Explain this${l} code:\n\n\`\`\`${lang}\n${code}\n\`\`\``;
-      return `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`;
-    },
+    url: (code, lang, preset) =>
+      `https://chatgpt.com/?q=${encodeURIComponent(buildPrompt(code, lang, preset))}`,
   },
   {
     id: "gemini",
@@ -208,10 +243,8 @@ const AGENTS: AgentItem[] = [
         />
       </svg>
     ),
-    url: (code, lang) => {
-      const prompt = `Explain this${lang ? ` ${lang}` : ""} code:\n\n\`\`\`${lang}\n${code}\n\`\`\``;
-      return `https://gemini.google.com/app?q=${encodeURIComponent(prompt)}`;
-    },
+    url: (code, lang, preset) =>
+      `https://gemini.google.com/app?q=${encodeURIComponent(buildPrompt(code, lang, preset))}`,
   },
 ];
 
@@ -257,8 +290,9 @@ export default function OpenInAgentButton({
     (agent: AgentItem) => {
       const code = getNearestCodeText(wrapperRef.current);
       const lang = getNearestLanguage(wrapperRef.current);
+      const preset = getNearestPromptPreset(wrapperRef.current);
       if (!code) return;
-      window.open(agent.url(code, lang), "_blank", "noopener");
+      window.open(agent.url(code, lang, preset), "_blank", "noopener");
       setIsOpen(false);
     },
     [],

--- a/documentation/site/src/shared/components/OpenInAgentButton/index.tsx
+++ b/documentation/site/src/shared/components/OpenInAgentButton/index.tsx
@@ -300,7 +300,7 @@ export default function OpenInAgentButton({
           <path d="M10 18v4" />
           <path d="M14 18v4" />
         </svg>
-        <span className={styles.label}>Agent</span>
+        <span className={styles.label}>Use an Agent</span>
         <svg
           width="10"
           height="10"

--- a/documentation/site/src/shared/components/OpenInAgentButton/index.tsx
+++ b/documentation/site/src/shared/components/OpenInAgentButton/index.tsx
@@ -1,7 +1,5 @@
-/*
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-*/
 
 /**
  * OpenInAgentButton — shared dropdown that lets users send a code snippet to an

--- a/documentation/site/src/shared/components/OpenInAgentButton/styles.module.css
+++ b/documentation/site/src/shared/components/OpenInAgentButton/styles.module.css
@@ -2,7 +2,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 */
-/* Wrapper keeps the dropdown anchored to the trigger button */
 .wrapper {
   position: relative;
   display: inline-flex;

--- a/documentation/site/src/shared/components/OpenInAgentButton/styles.module.css
+++ b/documentation/site/src/shared/components/OpenInAgentButton/styles.module.css
@@ -2,13 +2,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 */
-/* Wrapper keeps the dropdown anchored to the trigger button.
-  Override Docusaurus button-bar opacity so the button is always visible. */
+/* Wrapper keeps the dropdown anchored to the trigger button */
 .wrapper {
   position: relative;
   display: inline-flex;
-  opacity: 1 !important;
-  visibility: visible !important;
 }
 
 /* Trigger button: inherits code-block button styling from the theme.
@@ -104,4 +101,12 @@
   font-size: 12px;
   opacity: 0.65;
   line-height: 1.4;
+}
+
+/* Force the Docusaurus code block button group to always be visible.
+  By default it hides with opacity:0 and only shows on hover. */
+:global(.buttonGroup_node_modules),
+:global([class*="buttonGroup_"]) {
+  opacity: 1 !important;
+  transition: none !important;
 }

--- a/documentation/site/src/shared/components/OpenInAgentButton/styles.module.css
+++ b/documentation/site/src/shared/components/OpenInAgentButton/styles.module.css
@@ -2,10 +2,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 */
-/* Wrapper keeps the dropdown anchored to the trigger button */
+/* Wrapper keeps the dropdown anchored to the trigger button.
+  Override Docusaurus button-bar opacity so the button is always visible. */
 .wrapper {
   position: relative;
   display: inline-flex;
+  opacity: 1 !important;
+  visibility: visible !important;
 }
 
 /* Trigger button: inherits code-block button styling from the theme.

--- a/documentation/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
+++ b/documentation/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
@@ -77,7 +77,7 @@ export default function CopyButton({ className }: Props): ReactNode {
   const { copyCode, isCopied } = useCopyButton(buttonRef);
 
   return (
-    <span ref={buttonRef}>
+    <span ref={buttonRef} style={{ display: "contents" }}>
       <Button
         aria-label={ariaLabel(isCopied)}
         title={title()}

--- a/documentation/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
+++ b/documentation/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
@@ -99,10 +99,7 @@ export default function CopyButton({ className }: Props): ReactNode {
           </span>
         </span>
       </Button>
-      <OpenInAgentButton
-        className={className}
-        ButtonComponent={Button}
-      />
+      <OpenInAgentButton className={className} />
     </span>
   );
 }

--- a/documentation/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
+++ b/documentation/site/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
@@ -13,6 +13,7 @@ import { translate } from "@docusaurus/Translate";
 import Button from "@theme/CodeBlock/Buttons/Button";
 import type { Props } from "@theme/CodeBlock/Buttons/CopyButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import OpenInAgentButton from "../../../../shared/components/OpenInAgentButton";
 
 function getNearestCodeText(start: HTMLElement | null): string | null {
   let el: HTMLElement | null = start;
@@ -98,6 +99,10 @@ export default function CopyButton({ className }: Props): ReactNode {
           </span>
         </span>
       </Button>
+      <OpenInAgentButton
+        className={className}
+        ButtonComponent={Button}
+      />
     </span>
   );
 }

--- a/documentation/site/src/theme/CodeBlock/index.tsx
+++ b/documentation/site/src/theme/CodeBlock/index.tsx
@@ -3,7 +3,13 @@ import type {Props} from '@theme/CodeBlock';
 import OriginalCodeBlock from '@theme-original/CodeBlock';
 
 export default function CodeBlock(props: Props) {
-  // Delegate to the theme's original component so we keep its Context provider
-  // and any built-in behavior, while still allowing future customizations here.
-  return <OriginalCodeBlock {...props} />;
+  const meta = (props as any).metastring ?? '';
+  const match = meta.match(/agentPrompt="([^"]+)"/);
+  const prompt = match?.[1];
+
+  return (
+    <div data-agent-prompt={prompt}>
+      <OriginalCodeBlock {...props} />
+    </div>
+  );
 }


### PR DESCRIPTION
Adds the OpenInAgentButton dropdown to all code blocks, rendering alongside the existing Copy button. Users can send code snippets to Claude, ChatGPT, or Gemini.