### PR TITLE
build(suins-indexer): declare GIT_REVISION after source COPYs to preserve layer cache

### DIFF
--- a/docker/suins-indexer/Dockerfile
+++ b/docker/suins-indexer/Dockerfile
@@ -1,8 +1,6 @@
 FROM rust:1.90.0-bullseye AS builder
 
 ARG PROFILE=release
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
 
 WORKDIR work
 
@@ -12,6 +10,10 @@ COPY docker/suins-indexer/entry.sh ./
 
 RUN apt-get update && apt-get install -y build-essential libssl-dev pkg-config curl cmake clang ca-certificates
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+# GIT_REVISION declared late so SHA changes don't invalidate the COPY + apt layers above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
 
 RUN cargo build --profile $PROFILE --bin suins-indexer --config net.git-fetch-with-cli=true
 


### PR DESCRIPTION
## What
Move `ARG GIT_REVISION` / `ENV GIT_REVISION` in `docker/suins-indexer/Dockerfile` from the **top** of the builder stage to **just before `cargo build`** (below the source `COPY`s and the `apt-get install`).

## Why
`GIT_REVISION` changes on **every commit**. Declared at the top of the builder stage, it invalidated every layer below it on every build — the source `COPY`s, the `apt-get install` (build-essential/cmake/clang/libssl/…), and the cargo build — **even for commits that don't touch `indexer/`**. Declaring it late keeps the `COPY` and `apt-get` layers cached across commits, so unrelated commits and SHA-only rebuilds skip the apt install and source re-copy.

`GIT_REVISION` is only consumed by the **runtime-stage `LABEL`** (which already declares its own `ARG GIT_REVISION`) — there's no `build.rs` / `env!` / `vergen` usage of it in the crate — so moving it below the source COPYs does not change the built binary.

## Background (not the thesis)
This image isn't on mp3's rewriter/stateful-pool build caching (it pins `rust:1.90`, off the 1.92/1.93 overlay path), so this layer-ordering fix is the available win today. A larger, separate follow-up could add a cargo deps-caching stage / `--mount=type=cache` — and, since `GIT_REVISION` isn't consumed by the build, drop it from the builder entirely — for a cargo-compile cache win. Left out here to keep this change minimal and low-risk.

## Test plan
- Pure layer-ordering change; `GIT_REVISION` is still set before `cargo build` and still stamped into the runtime `git-revision` LABEL.
- `docker build` succeeds and the `git-revision` LABEL is still populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)