### PR TITLE
feat(docs): add Kapa.ai sidebar integration

### DIFF
--- a/documentation/site/docusaurus.config.js
+++ b/documentation/site/docusaurus.config.js
@@ -96,6 +96,28 @@ const config = {
       };
     },
   ],
+  clientModules: [
+    require.resolve("./src/client/kapa-sidebar.js"),
+  ],
+
+  scripts: [
+    {
+      src: "https://widget.kapa.ai/kapa-widget.bundle.js",
+      "data-website-id": "41cc6485-0b9b-41c9-ac5e-c2965afde07c",
+      "data-project-name": "SuiNS Knowledge",
+      "data-project-color": "#298DFF",
+      "data-button-hide": "true",
+      "data-view-mode": "sidebar",
+      "data-modal-title": "Ask SuiNS AI",
+      "data-modal-ask-ai-input-placeholder": "Ask me anything about SuiNS!",
+      "data-modal-example-questions": "How do I register a SuiNS name?,What is MVR?,How do I resolve a name on-chain?,How do I set up a subdomain?",
+      "data-modal-overlay-hidden": "true",
+      "data-modal-lock-scroll": "false",
+      "data-modal-image": "/img/logo.svg",
+      async: true,
+    },
+  ],
+
   presets: [
     [
       "classic",

--- a/documentation/site/docusaurus.config.js
+++ b/documentation/site/docusaurus.config.js
@@ -103,7 +103,7 @@ const config = {
   scripts: [
     {
       src: "https://widget.kapa.ai/kapa-widget.bundle.js",
-      "data-website-id": "41cc6485-0b9b-41c9-ac5e-c2965afde07c",
+      "data-website-id": "c34a7507-f7d9-4db2-bd58-69a670ea2b57",
       "data-project-name": "SuiNS Knowledge",
       "data-project-color": "#298DFF",
       "data-button-hide": "true",

--- a/documentation/site/src/client/kapa-sidebar.js
+++ b/documentation/site/src/client/kapa-sidebar.js
@@ -1,0 +1,82 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Detects Kapa sidebar open/close and toggles .kapa-sidebar-open on <html>.
+// Kapa renders in Shadow DOM so we can't query its internals.
+// Strategy: hook Kapa.open for instant open detection, then use
+// elementFromPoint to detect close (checks if right edge of screen
+// is covered by a non-docusaurus element).
+
+if (typeof window !== "undefined") {
+  const OPEN_CLASS = "kapa-sidebar-open";
+  let kapaOpen = false;
+  let hookedRef = null;
+
+  function syncClass() {
+    document.documentElement.classList.toggle(OPEN_CLASS, kapaOpen);
+  }
+
+  function hookKapa() {
+    if (!window.Kapa || !window.Kapa.open || window.Kapa.open === hookedRef) return;
+
+    const origOpen = window.Kapa.open;
+    const origClose = window.Kapa.close;
+
+    window.Kapa.open = function (...args) {
+      kapaOpen = true;
+      syncClass();
+      return origOpen.apply(this, args);
+    };
+
+    window.Kapa.close = function (...args) {
+      kapaOpen = false;
+      syncClass();
+      return origClose.apply(this, args);
+    };
+
+    hookedRef = window.Kapa.open;
+  }
+
+  // Check if Kapa sidebar is covering the right side of the viewport
+  function isSidebarVisible() {
+    const x = window.innerWidth - 50;
+    const y = window.innerHeight / 2;
+    const el = document.elementFromPoint(x, y);
+    if (!el) return false;
+    // If the element at the right edge is inside #__docusaurus, sidebar is closed
+    const docRoot = document.getElementById("__docusaurus");
+    if (docRoot && docRoot.contains(el)) return false;
+    // If it's the body or html itself, sidebar is closed
+    if (el === document.body || el === document.documentElement) return false;
+    // Otherwise something (Kapa) is covering that spot
+    return true;
+  }
+
+  // Navigation hooks for SPA
+  const origPush = history.pushState.bind(history);
+  const origReplace = history.replaceState.bind(history);
+  history.pushState = function (...args) {
+    const r = origPush(...args);
+    syncClass();
+    return r;
+  };
+  history.replaceState = function (...args) {
+    const r = origReplace(...args);
+    syncClass();
+    return r;
+  };
+  window.addEventListener("popstate", syncClass);
+
+  // Poll every 300ms
+  setInterval(() => {
+    hookKapa();
+
+    const visible = isSidebarVisible();
+    if (visible && !kapaOpen) {
+      kapaOpen = true;
+    } else if (!visible && kapaOpen) {
+      kapaOpen = false;
+    }
+    syncClass();
+  }, 300);
+}

--- a/documentation/site/src/css/custom.css
+++ b/documentation/site/src/css/custom.css
@@ -326,3 +326,92 @@ img {
   opacity: 1 !important;
   transition: none !important;
 }
+
+/* ---- Kapa sidebar content shift ---- */
+/* Kapa renders in Shadow DOM so CSS :has() can't detect it.
+   A client module (kapa-sidebar.js) toggles .kapa-sidebar-open on <html>. */
+html.kapa-sidebar-open body {
+  width: calc(100vw - 500px) !important;
+  overflow-x: hidden;
+  transition: width 0.3s ease;
+}
+
+html.kapa-sidebar-open .navbar,
+html.kapa-sidebar-open .navbar--fixed-top {
+  right: 500px !important;
+  overflow: hidden;
+  transition: right 0.3s ease;
+}
+
+/* Hide the Ask AI and Search buttons in navbar when sidebar is open
+   since Kapa is already visible */
+html.kapa-sidebar-open .kapa-trigger-btn,
+html.kapa-sidebar-open .DocSearch-Button {
+  display: none !important;
+}
+
+.navbar,
+.navbar--fixed-top {
+  transition: right 0.3s ease;
+}
+
+/* Hide the desktop TOC column when sidebar is open to free space */
+html.kapa-sidebar-open .col.col--3:has(.theme-doc-toc-desktop) {
+  display: none;
+}
+
+/* Let the main content column expand to fill the freed space */
+html.kapa-sidebar-open .col[class*="docItemCol"] {
+  max-width: 100% !important;
+  flex: 1 !important;
+}
+
+body {
+  transition: width 0.3s ease;
+}
+
+@media (max-width: 768px) {
+  html.kapa-sidebar-open body {
+    width: 100vw !important;
+  }
+}
+
+/* Kapa trigger button styles */
+.kapa-trigger-btn {
+  @apply flex items-center gap-2.5 cursor-pointer font-semibold text-base rounded-full;
+  padding: 0.625rem 1.25rem;
+  border: 1px solid var(--color-suins-gray-20);
+  background: var(--color-suins-white-100);
+  color: var(--color-suins-gray-100);
+  transition: background-color 0.15s;
+}
+
+.kapa-trigger-btn:hover {
+  background: var(--color-suins-gray-5);
+}
+
+html[data-theme='dark'] .kapa-trigger-btn {
+  background: var(--color-suins-gray-80);
+  color: var(--color-suins-white-100);
+  border-color: var(--color-suins-gray-60);
+}
+
+html[data-theme='dark'] .kapa-trigger-btn:hover {
+  background: var(--color-suins-gray-70);
+}
+
+/* Compact kapa button below full desktop width */
+@media screen and (max-width: 1399px) {
+  .navbar .kapa-trigger-btn {
+    width: 42px;
+    height: 42px;
+    min-width: 42px;
+    padding: 0 !important;
+    justify-content: center;
+    margin: 0;
+  }
+
+  .navbar .kapa-trigger-btn span {
+    display: none;
+  }
+}

--- a/documentation/site/src/theme/Navbar/Content/index.js
+++ b/documentation/site/src/theme/Navbar/Content/index.js
@@ -97,6 +97,25 @@ function SearchLauncher() {
   );
 }
 
+function KapaButton() {
+  const handleClick = () => {
+    if (typeof window !== "undefined" && window.Kapa) {
+      window.Kapa.open();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="kapa-trigger-btn"
+    >
+      <img src="/img/logo.svg" alt="" width="23" height="23" />
+      <span>Ask SuiNS AI</span>
+    </button>
+  );
+}
+
 export default function NavbarContent() {
   const mobileSidebar = useMobileSidebarSafe();
   const items = useNavbarItems();
@@ -116,6 +135,7 @@ export default function NavbarContent() {
         <>
           <NavbarItems items={rightItems} />
           <ThemeToggle />
+          <KapaButton />
           {!searchBarItem && (
             <NavbarSearch>
               <SearchLauncher />


### PR DESCRIPTION
## Summary
- Add Kapa.ai widget configured in sidebar mode with hidden default button
- Add "Ask SuiNS AI" trigger button to existing custom Navbar component
- Add `kapa-sidebar.js` client module to detect sidebar open/close state and toggle CSS class on `<html>`
- Add CSS rules for 500px content shift, navbar adjustment, TOC hiding, and mobile responsiveness

## Test plan
- [ ] Run `pnpm build` locally to verify no build errors
- [ ] Verify Kapa widget loads on the site (requires `KAPA_API_KEY_SUINS` secret)
- [ ] Click "Ask SuiNS AI" button in navbar — sidebar should open on the right
- [ ] Verify content shifts left by 500px when sidebar is open
- [ ] Verify sidebar goes full-screen on mobile (< 768px)
- [ ] Verify button collapses to icon-only below 1400px viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)