### PR TITLE
[SUIP-1105] chore(bbb): network-aware bbb upgrade script + fix mainnet Published.toml

### DIFF
--- a/.github/workflows/suins-build-tx.yaml
+++ b/.github/workflows/suins-build-tx.yaml
@@ -249,7 +249,7 @@ jobs:
           ORIGIN: gh_action
           RPC_URL: ${{ inputs.rpc }}
         run: |
-          cd scripts && pnpm ts-node transactions/bbb_upgrade.ts mainnet
+          cd scripts && pnpm ts-node transactions/bbb_upgrade.ts
 
       - name: Show Transaction Data (To sign)
         run: |

--- a/.github/workflows/suins-build-tx.yaml
+++ b/.github/workflows/suins-build-tx.yaml
@@ -249,7 +249,7 @@ jobs:
           ORIGIN: gh_action
           RPC_URL: ${{ inputs.rpc }}
         run: |
-          cd scripts && pnpm ts-node transactions/bbb_upgrade.ts
+          cd scripts && pnpm ts-node transactions/bbb_upgrade.ts mainnet
 
       - name: Show Transaction Data (To sign)
         run: |

--- a/packages/bbb/Published.toml
+++ b/packages/bbb/Published.toml
@@ -4,6 +4,6 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x6268d072063a311f6f0a1db516d06d97c06a3fa6d10e797cad578937a47b3992"
+published-at = "0x52479fe0e990f5bac0008af20ad072b0cc0ffbc0b2d7981e961360373b1fbda7"
 original-id = "0x6268d072063a311f6f0a1db516d06d97c06a3fa6d10e797cad578937a47b3992"
-version = 1
+version = 2

--- a/scripts/transactions/bbb_upgrade.ts
+++ b/scripts/transactions/bbb_upgrade.ts
@@ -4,7 +4,9 @@
 import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 
-type Network = 'mainnet' | 'testnet';
+import { Network } from '../config/constants';
+
+const network = (process.env.NETWORK as Network) || 'mainnet';
 
 const BBB_UPGRADE_CAP: Record<Network, string> = {
 	mainnet: '0x7be6340da3af6cf40f2d77f289e178631f8c3e479167099b93769c5f1b82e6f9',
@@ -12,13 +14,9 @@ const BBB_UPGRADE_CAP: Record<Network, string> = {
 };
 
 const bbbUpgrade = async () => {
-	const network = process.argv[2] as Network;
-	if (network !== 'mainnet' && network !== 'testnet')
-		throw new Error('Network must be "mainnet" or "testnet"');
-
 	const gasObjectId = process.env.GAS_OBJECT;
 
-	if (!gasObjectId) throw new Error('No gas object supplied for a mainnet transaction');
+	if (!gasObjectId) throw new Error('No gas object supplied. Export it using GAS_OBJECT');
 
 	const currentDir = process.cwd();
 	const bbbDir = `${currentDir}/../packages/bbb`;

--- a/scripts/transactions/bbb_upgrade.ts
+++ b/scripts/transactions/bbb_upgrade.ts
@@ -4,9 +4,18 @@
 import { execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 
-const BBB_UPGRADE_CAP = '0x7be6340da3af6cf40f2d77f289e178631f8c3e479167099b93769c5f1b82e6f9';
+type Network = 'mainnet' | 'testnet';
+
+const BBB_UPGRADE_CAP: Record<Network, string> = {
+	mainnet: '0x7be6340da3af6cf40f2d77f289e178631f8c3e479167099b93769c5f1b82e6f9',
+	testnet: '0x558d953cfff029f9dff7b42bb0e589b70441230112eb688eb7bd5ed908d4bd3c',
+};
 
 const bbbUpgrade = async () => {
+	const network = process.argv[2] as Network;
+	if (network !== 'mainnet' && network !== 'testnet')
+		throw new Error('Network must be "mainnet" or "testnet"');
+
 	const gasObjectId = process.env.GAS_OBJECT;
 
 	if (!gasObjectId) throw new Error('No gas object supplied for a mainnet transaction');
@@ -14,7 +23,7 @@ const bbbUpgrade = async () => {
 	const currentDir = process.cwd();
 	const bbbDir = `${currentDir}/../packages/bbb`;
 	const txFilePath = `${currentDir}/tx/tx-data.txt`;
-	const upgradeCall = `sui client upgrade --upgrade-capability ${BBB_UPGRADE_CAP} --gas-budget 2000000000 --gas ${gasObjectId} --skip-dependency-verification --serialize-unsigned-transaction`;
+	const upgradeCall = `sui client upgrade --upgrade-capability ${BBB_UPGRADE_CAP[network]} --gas-budget 2000000000 --gas ${gasObjectId} --skip-dependency-verification --serialize-unsigned-transaction`;
 
 	try {
 		const output = execSync(upgradeCall, { cwd: bbbDir, stdio: 'pipe' }).toString();


### PR DESCRIPTION

### Description
General housekeeping on the `bbb` package upgrade readiness within this repo:
* adds a mainnet/testnet argument to the BBB upgrade script (with a per-network UpgradeCap) and wires the build-tx workflow to pass it
* corrects the mainnet BBB `Published.toml` to the on-chain v2 package — the v1→v2 upgrade metadata was never committed.


### Comments
1. There is a pre-existing failure on the Move formatting rule, will be fixed with the separate PR https://github.com/MystenLabs/suins-contracts/pull/397 for consistency (after merging the formatting PR, will merge main back to the current branch, so the formatting check passes here before merging it, too)