### PR TITLE
[SUIP-1105] chore(move): format flagged files with prettier-move

### DIFF
--- a/packages/payments/tests/payments_tests.move
+++ b/packages/payments/tests/payments_tests.move
@@ -19,7 +19,7 @@ use suins_payments::{
         new_coin_type_data,
         handle_base_payment,
         PaymentsApp,
-        PaymentsConfig
+        PaymentsConfig,
     },
     testns::TESTNS,
     testusdc::TESTUSDC

--- a/packages/suins/tests/auction_tests.move
+++ b/packages/suins/tests/auction_tests.move
@@ -18,7 +18,7 @@ use suins::{
         admin_finalize_auction,
         admin_try_finalize_auctions,
         admin_withdraw_funds,
-        collect_winning_auction_fund
+        collect_winning_auction_fund,
     },
     constants::{Self, mist_per_sui},
     core_config,

--- a/packages/voting/sources/staking/config.move
+++ b/packages/voting/sources/staking/config.move
@@ -15,23 +15,33 @@ const EInvalidMinBalance: u64 = 104;
 // === constants (initial values, and min/max values the admin can set) ===
 
 public(package) macro fun init_cooldown_ms(): u64 { day_ms!() * 14 } // 14 days
+
 public(package) macro fun min_cooldown_ms(): u64 { 0 } // instant
+
 public(package) macro fun max_cooldown_ms(): u64 { month_ms!() } // 30 days
 
 public(package) macro fun init_monthly_boost_bps(): u64 { 110_00 } // 1.1x
+
 public(package) macro fun min_monthly_boost_bps(): u64 { 101_00 } // 1.01x
+
 public(package) macro fun max_monthly_boost_bps(): u64 { 300_00 } // 3x
 
 public(package) macro fun init_max_boost_bps(): u64 { 300_00 } // 3x
+
 public(package) macro fun min_max_boost_bps(): u64 { 105_00 } // 1.05x
+
 public(package) macro fun max_max_boost_bps(): u64 { 1500_00 } // 15x
 
 public(package) macro fun init_max_lock_months(): u64 { 12 } // 12 months
+
 public(package) macro fun min_max_lock_months(): u64 { 3 } // 3 months
+
 public(package) macro fun max_max_lock_months(): u64 { 36 } // 3 years
 
 public(package) macro fun init_min_balance(): u64 { 100_000 } // 0.1 NS
+
 public(package) macro fun min_min_balance(): u64 { 1_000 } // 0.001 NS
+
 public(package) macro fun max_min_balance(): u64 { 1_000_000_000 } // 1000 NS
 
 // === structs ===

--- a/packages/voting/tests/proposal_v2_tests.move
+++ b/packages/voting/tests/proposal_v2_tests.move
@@ -14,7 +14,7 @@ use suins_voting::{
         assert_owns_ns,
         proposal__new__end_time,
         reward_amount,
-        admin_addr
+        admin_addr,
     },
     voting_option::{Self, threshold_not_reached, tie_rejected}
 };

--- a/packages/voting/tests/test_utils.move
+++ b/packages/voting/tests/test_utils.move
@@ -26,6 +26,7 @@ use suins_voting::{
 // === constants ===
 
 public macro fun admin_addr(): address { @0xaa1 }
+
 public macro fun reward_amount(): u64 { 1_000_000 }
 
 const INITIAL_TIME: u64 = 86_400_000; // January 2, 1970


### PR DESCRIPTION
### Description
Applies `prettier-move` formatting to the 5 files the move-formatter CI gate flags (trailing commas on multi-line `use` blocks, blank lines between one-line macros). No logic changes.