### PR TITLE
[SUIP-1105] chore(scripts): payments upgrade script + GH action

### DIFF
--- a/.github/workflows/suins-build-tx.yaml
+++ b/.github/workflows/suins-build-tx.yaml
@@ -23,6 +23,7 @@ on:
           - Transfer Suins Name
           - Authorize Payments
           - Upgrade BBB
+          - Upgrade Payments
       sui_tools_image:
         description: 'image reference of sui_tools'
         default: 'mysten/sui-tools:mainnet'
@@ -250,6 +251,17 @@ jobs:
           RPC_URL: ${{ inputs.rpc }}
         run: |
           cd scripts && pnpm ts-node transactions/bbb_upgrade.ts
+
+      - name: Upgrade Payments
+        if: ${{ inputs.transaction_type == 'Upgrade Payments' }}
+        env:
+          NODE_ENV: production
+          GAS_OBJECT: ${{ inputs.gas_object_id }}
+          NETWORK: mainnet
+          ORIGIN: gh_action
+          RPC_URL: ${{ inputs.rpc }}
+        run: |
+          cd scripts && pnpm ts-node transactions/payments_upgrade.ts
 
       - name: Show Transaction Data (To sign)
         run: |

--- a/scripts/config/constants.ts
+++ b/scripts/config/constants.ts
@@ -38,6 +38,10 @@ export type PackageInfo = {
 	treasuryAddress?: string;
 	payments: {
 		packageId: string;
+		upgradeCap: string;
+	};
+	bbb: {
+		upgradeCap: string;
 	};
 	pyth: {
 		pythStateId: string;
@@ -87,6 +91,10 @@ export const mainPackage: Config = {
 		treasuryAddress: '0x638791b625c4482bc1b917847cdf8aa76fe226c0f3e0a9b1aa595625989e98a1',
 		payments: {
 			packageId: '0xdd0a4a34152a80d7841710e916a407b2a62961eee5b2188dcfdaa24194f66286',
+			upgradeCap: '0x1b81a62cca9db85bacdf213780e6ae71722ad3939f815cdbd6f577aa5d8ff8d2',
+		},
+		bbb: {
+			upgradeCap: '0x7be6340da3af6cf40f2d77f289e178631f8c3e479167099b93769c5f1b82e6f9',
 		},
 		pyth: {
 			pythStateId: '0x1f9310238ee9298fb703c3419030b35b22bb1cc37113e3bb5007c99aec79e5b8',
@@ -138,7 +146,11 @@ export const mainPackage: Config = {
 			packageId: '0x63029aae8abbefae4f4ac6c5e3e0021159ea93a94ba648681fd64caf5b40677a',
 		},
 		payments: {
-			packageId: '0x9e8b85270cf5e7ec0ae44c745abe000b6dd7d8b54ca2d367e044d8baccefc10c',
+			packageId: '0xc391c200188dd1a363ff12dcffe07eaac5cf28ad1cd8dc0fcc18f2f8625f0da2',
+			upgradeCap: '0x06904d75de990102ef09f81e4ca96fcf85698d00768ab3d76179ef6cda07e545',
+		},
+		bbb: {
+			upgradeCap: '0x558d953cfff029f9dff7b42bb0e589b70441230112eb688eb7bd5ed908d4bd3c',
 		},
 		pyth: {
 			pythStateId: '0x243759059f4c3111179da5878c12f68d612c21a8d54d85edc86164bb18be1c7c',

--- a/scripts/transactions/bbb_upgrade.ts
+++ b/scripts/transactions/bbb_upgrade.ts
@@ -8,7 +8,7 @@ import { mainPackage, Network } from '../config/constants';
 
 const network = (process.env.NETWORK as Network) || 'mainnet';
 
-const bbbUpgrade = async () => {
+const bbbUpgrade = () => {
 	const gasObjectId = process.env.GAS_OBJECT;
 
 	if (!gasObjectId) throw new Error('No gas object supplied. Export it using GAS_OBJECT');

--- a/scripts/transactions/payments_upgrade.ts
+++ b/scripts/transactions/payments_upgrade.ts
@@ -8,7 +8,7 @@ import { mainPackage, Network } from '../config/constants';
 
 const network = (process.env.NETWORK as Network) || 'mainnet';
 
-const paymentsUpgrade = async () => {
+const paymentsUpgrade = () => {
 	const gasObjectId = process.env.GAS_OBJECT;
 
 	if (!gasObjectId) throw new Error('No gas object supplied. Export it using GAS_OBJECT');

--- a/scripts/transactions/payments_upgrade.ts
+++ b/scripts/transactions/payments_upgrade.ts
@@ -8,24 +8,24 @@ import { mainPackage, Network } from '../config/constants';
 
 const network = (process.env.NETWORK as Network) || 'mainnet';
 
-const bbbUpgrade = async () => {
+const paymentsUpgrade = async () => {
 	const gasObjectId = process.env.GAS_OBJECT;
 
 	if (!gasObjectId) throw new Error('No gas object supplied. Export it using GAS_OBJECT');
 
-	const upgradeCap = mainPackage[network].bbb.upgradeCap;
+	const upgradeCap = mainPackage[network].payments.upgradeCap;
 
 	const currentDir = process.cwd();
-	const bbbDir = `${currentDir}/../packages/bbb`;
+	const paymentsDir = `${currentDir}/../packages/payments`;
 	const txFilePath = `${currentDir}/tx/tx-data.txt`;
 	const upgradeCall = `sui client upgrade --upgrade-capability ${upgradeCap} --gas-budget 2000000000 --gas ${gasObjectId} --skip-dependency-verification --serialize-unsigned-transaction`;
 
 	try {
-		const output = execSync(upgradeCall, { cwd: bbbDir, stdio: 'pipe' }).toString();
+		const output = execSync(upgradeCall, { cwd: paymentsDir, stdio: 'pipe' }).toString();
 		writeFileSync(txFilePath, output);
-		console.log('BBB upgrade transaction successfully created and saved to tx-data.txt');
+		console.log('Payments upgrade transaction successfully created and saved to tx-data.txt');
 	} catch (error: any) {
-		console.error('Error during BBB upgrade:', error.message);
+		console.error('Error during Payments upgrade:', error.message);
 		console.error('stderr:', error.stderr?.toString());
 		console.error('stdout:', error.stdout?.toString());
 		console.error('Command:', error.cmd);
@@ -33,4 +33,4 @@ const bbbUpgrade = async () => {
 	}
 };
 
-bbbUpgrade();
+paymentsUpgrade();


### PR DESCRIPTION
### Linear Ticket
For the full context, see the related linear ticket: https://linear.app/mysten-labs/issue/SUIP-1105/suins-contracts-bump-on-chain-pyth-package-for-pro-sui

### Description
Adds the tooling to build the payments in-place upgrade transaction, mirroring the existing bbb flow: a network-aware `payments_upgrade.ts` and an `Upgrade Payments` step in the build-tx workflow. Both upgrade scripts now read their `UpgradeCap` from `constants.ts` (single source of truth) instead of a hardcoded map, matching the `coupons_upgrade` pattern. Also fixes the testnet `payments.packageId` to match the SDK (`0xc391c200…`) and records the payments/bbb upgrade caps in `constants.ts`.